### PR TITLE
Gsp nans

### DIFF
--- a/nowcasting_datamodel/models/gsp.py
+++ b/nowcasting_datamodel/models/gsp.py
@@ -8,6 +8,8 @@ import logging
 from datetime import datetime
 from typing import Optional
 
+import numpy as np
+
 from pydantic import Field, validator
 from sqlalchemy import Column, DateTime, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import relationship
@@ -106,6 +108,9 @@ class GSPYield(EnhancedBaseModel):
         if v < 0:
             logger.debug(f"Changing solar_generation_kw ({v}) to 0")
             v = 0
+        if np.isnan(v):
+            logger.debug(f"Changing solar_generation_kw ({v}) to -1")
+            v = -1
         return v
 
     @validator("regime")

--- a/tests/models/test_gsp.py
+++ b/tests/models/test_gsp.py
@@ -1,0 +1,10 @@
+from nowcasting_datamodel.models.gsp import GSPYield
+from datetime import datetime
+import numpy as np
+
+
+def test_gsp_validation():
+
+    gsp_yield = GSPYield(datetime_utc=datetime(2022,1,1),solar_generation_kw=np.nan)
+
+    assert gsp_yield.solar_generation_kw == -1


### PR DESCRIPTION
# Pull Request

## Description

All nan GSP yields solar generations goes to -1. This makes them jsonifable

## How Has This Been Tested?

add a test

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
