### PR TITLE
add function to read created_utc from database

### DIFF
--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -84,7 +84,7 @@ def make_fake_forecasts(
 
 def make_fake_national_forecast(t0_datetime_utc: Optional[datetime] = None) -> ForecastSQL:
     """Make national fake forecast"""
-    location = LocationSQL(label=national_gb_label)
+    location = LocationSQL(label=national_gb_label, gsp_id=0)
     model = MLModelSQL(name="fake_model_national", version="0.1.2")
     input_data_last_updated = make_fake_input_data_last_updated()
 

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -233,6 +233,33 @@ def get_latest_national_forecast(
     return forecast
 
 
+def get_latest_forecast_created_utc(session: Session, gsp_id: int) -> datetime:
+    """
+    Get the latest forecast created utc value. Can choose for different gsps
+
+    :param session: database session
+    :param gsp_id: gsp id to filter query on
+    :return:
+    """
+
+    # start main query
+    query = session.query(ForecastSQL.created_utc)
+
+    # filter on gsp_id
+    query = query.join(LocationSQL)
+    query = query.filter(LocationSQL.gsp_id == gsp_id)
+
+    # order, so latest is at the top
+    query = query.order_by(ForecastSQL.created_utc.desc())
+
+    # get first results
+    created_utc = query.first()
+
+    assert len(created_utc) == 1
+
+    return created_utc[0]
+
+
 def get_location(session: Session, gsp_id: int, label: Optional[str] = None) -> LocationSQL:
     """
     Get location object from gsp id

--- a/tests/read/test_read.py
+++ b/tests/read/test_read.py
@@ -23,6 +23,7 @@ from nowcasting_datamodel.read.read import (
     get_all_locations,
     get_forecast_values,
     get_latest_forecast,
+    get_latest_forecast_created_utc,
     get_latest_input_data_last_updated,
     get_latest_national_forecast,
     get_location,
@@ -104,6 +105,30 @@ def test_get_forecast_values_gsp_id(db_session, forecasts):
     assert len(forecast_values_read) == 2
 
     assert forecast_values_read[0] == forecasts[0].forecast_values[0]
+
+
+
+def test_get_latest_forecast_created_utc_gsp(db_session):
+    f1 = make_fake_forecast(gsp_id=1, session=db_session)
+    f2 = make_fake_forecast(gsp_id=1, session=db_session)
+    f3 = make_fake_forecast(gsp_id=2, session=db_session)
+
+    db_session.add_all([f1,f2, f3])
+    db_session.commit()
+
+    created_utc = get_latest_forecast_created_utc(session=db_session, gsp_id=1)
+    assert created_utc == f2.created_utc
+
+
+def test_get_latest_forecast_created_utc_national(db_session):
+    f1 = make_fake_national_forecast()
+    f2 = make_fake_national_forecast()
+
+    db_session.add_all([f2,f1])
+    db_session.commit()
+
+    created_utc = get_latest_forecast_created_utc(session=db_session, gsp_id=0)
+    assert created_utc == f1.created_utc
 
 
 def test_get_forecast_values_gsp_id_latest(db_session):

--- a/tests/read/test_read.py
+++ b/tests/read/test_read.py
@@ -107,13 +107,12 @@ def test_get_forecast_values_gsp_id(db_session, forecasts):
     assert forecast_values_read[0] == forecasts[0].forecast_values[0]
 
 
-
 def test_get_latest_forecast_created_utc_gsp(db_session):
     f1 = make_fake_forecast(gsp_id=1, session=db_session)
     f2 = make_fake_forecast(gsp_id=1, session=db_session)
     f3 = make_fake_forecast(gsp_id=2, session=db_session)
 
-    db_session.add_all([f1,f2, f3])
+    db_session.add_all([f1, f2, f3])
     db_session.commit()
 
     created_utc = get_latest_forecast_created_utc(session=db_session, gsp_id=1)
@@ -124,7 +123,7 @@ def test_get_latest_forecast_created_utc_national(db_session):
     f1 = make_fake_national_forecast()
     f2 = make_fake_national_forecast()
 
-    db_session.add_all([f2,f1])
+    db_session.add_all([f2, f1])
     db_session.commit()
 
     created_utc = get_latest_forecast_created_utc(session=db_session, gsp_id=0)


### PR DESCRIPTION
# Pull Request

## Description

add function to read last created_utc time
this be useful for status board

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
