### PR TITLE
use joinedload to speed up gett all forecasts objects

### DIFF
--- a/nowcasting_datamodel/connection.py
+++ b/nowcasting_datamodel/connection.py
@@ -25,9 +25,8 @@ class DatabaseConnection:
         self.engine = create_engine(self.url, echo=echo)
 
         self.Session = sessionmaker(bind=self.engine)
-        
-        assert self.url is not None, \
-            Exception('Need to set url for database connection')
+
+        assert self.url is not None, Exception("Need to set url for database connection")
 
     def create_all(self):
         """Create all tables"""

--- a/nowcasting_datamodel/connection.py
+++ b/nowcasting_datamodel/connection.py
@@ -25,6 +25,9 @@ class DatabaseConnection:
         self.engine = create_engine(self.url, echo=echo)
 
         self.Session = sessionmaker(bind=self.engine)
+        
+        assert self.url is not None, \
+            Exception('Need to set url for database connection')
 
     def create_all(self):
         """Create all tables"""

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from sqlalchemy import desc
-from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm.session import Session
 
 from nowcasting_datamodel.models import (
@@ -159,8 +159,10 @@ def get_all_gsp_ids_latest_forecast(
     query = query.order_by(LocationSQL.gsp_id, desc(ForecastSQL.created_utc))
 
     if preload_children:
-        query = query.options(contains_eager(ForecastSQL.forecast_values))
-        query = query.options(contains_eager(ForecastSQL.location))
+        query = query.options(joinedload(ForecastSQL.forecast_values))
+        query = query.options(joinedload(ForecastSQL.location))
+        query = query.options(joinedload(ForecastSQL.model))
+        query = query.options(joinedload(ForecastSQL.input_data_last_updated))
 
     forecasts = query.all()
 

--- a/tests/read/test_read.py
+++ b/tests/read/test_read.py
@@ -175,12 +175,13 @@ def test_get_all_gsp_ids_latest_forecast_pre_load(db_session):
 
     f1 = make_fake_forecasts(gsp_ids=[1, 2], session=db_session)
 
-    forecast_values_read = get_all_gsp_ids_latest_forecast(
+    forecasts = get_all_gsp_ids_latest_forecast(
         session=db_session, preload_children=True
     )
-    assert len(forecast_values_read) == 2
-    assert forecast_values_read[0] == f1[0]
-    assert forecast_values_read[1] == f1[1]
+    assert len(forecasts) == 2
+    assert forecasts[0] == f1[0]
+    assert forecasts[1] == f1[1]
+    assert len(forecasts[0].forecast_values) == 2
 
 
 def test_get_all_gsp_ids_latest_forecast_filter(db_session):


### PR DESCRIPTION
# Pull Request

## Description

use 'joinedload' to pre load children. This means only one sql command is made. 
Fixes #48 

## How Has This Been Tested?

- unittests
- added a test

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
