### PR TITLE
make sure forecast values are ordered by targettime

### DIFF
--- a/nowcasting_datamodel/models/models.py
+++ b/nowcasting_datamodel/models/models.py
@@ -142,7 +142,9 @@ class ForecastValue(EnhancedBaseModel):
     def normalize(self, installed_capacity_mw):
         """Normalize forecasts by installed capacity mw"""
         if installed_capacity_mw in [0, None]:
-            logger.warning(f"Could not normalize ForecastValue object {installed_capacity_mw}")
+            logger.warning(f"Could not normalize ForecastValue object {installed_capacity_mw}"
+                           f"So will set to zero")
+            self.expected_power_generation_normalized = 0
         else:
             self.expected_power_generation_normalized = (
                 self.expected_power_generation_megawatts / installed_capacity_mw

--- a/nowcasting_datamodel/models/models.py
+++ b/nowcasting_datamodel/models/models.py
@@ -142,8 +142,10 @@ class ForecastValue(EnhancedBaseModel):
     def normalize(self, installed_capacity_mw):
         """Normalize forecasts by installed capacity mw"""
         if installed_capacity_mw in [0, None]:
-            logger.warning(f"Could not normalize ForecastValue object {installed_capacity_mw}"
-                           f"So will set to zero")
+            logger.warning(
+                f"Could not normalize ForecastValue object {installed_capacity_mw}"
+                f"So will set to zero"
+            )
             self.expected_power_generation_normalized = 0
         else:
             self.expected_power_generation_normalized = (

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -196,7 +196,7 @@ def sort_all_forecast_value(forecasts: List[ForecastSQL]):
     """
     """ Sorting all forecasts"""
 
-    logger.debug(f"sorting 'forecast_values_latest' or 'forecast_values' values. ")
+    logger.debug("sorting 'forecast_values_latest' or 'forecast_values' values.")
 
     for forecast in forecasts:
         sort_forecast_values(forecast=forecast)

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -11,7 +11,6 @@ from typing import List, Optional
 from sqlalchemy import desc
 from sqlalchemy.orm import contains_eager, joinedload
 from sqlalchemy.orm.session import Session
-from sqlalchemy.sql.expression import false, true
 
 from nowcasting_datamodel import N_GSP
 from nowcasting_datamodel.models import (

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -39,6 +39,7 @@ def test_normalize_forecasts_no_installed_capacity(forecasts_all):
     forecast.location.installed_capacity_mw = None
     forecast.normalize()
     assert forecast.forecast_values[0].expected_power_generation_megawatts == v
+    assert forecast.forecast_values[0].expected_power_generation_normalized == 0
 
 
 def test_status_validation():

--- a/tests/read/test_read.py
+++ b/tests/read/test_read.py
@@ -101,10 +101,10 @@ def test_read_target_time(db_session):
         target_time=datetime(2022, 1, 1), expected_power_generation_megawatts=1, gsp_id=1
     )
     f2 = ForecastValueLatestSQL(
-        target_time=datetime(2022, 1, 1, 0, 30), expected_power_generation_megawatts=2, gsp_id=1
+        target_time=datetime(2022, 1, 1, 1), expected_power_generation_megawatts=3, gsp_id=1
     )
     f3 = ForecastValueLatestSQL(
-        target_time=datetime(2022, 1, 1, 1), expected_power_generation_megawatts=3, gsp_id=1
+        target_time=datetime(2022, 1, 1, 0,30), expected_power_generation_megawatts=2, gsp_id=1
     )
     f = make_fake_forecast(gsp_id=1, session=db_session, forecast_values_latest=[f1, f2, f3])
     f.historic = True
@@ -119,6 +119,7 @@ def test_read_target_time(db_session):
     assert forecast_read.location.gsp_id == f.location.gsp_id
 
     assert len(forecast_read.forecast_values_latest) == 2
+    assert forecast_read.forecast_values_latest[-1].expected_power_generation_megawatts == 3
 
 
 def test_get_forecast_values(db_session, forecasts):
@@ -279,10 +280,10 @@ def test_get_all_gsp_ids_latest_forecast_filter_historic(db_session):
             gsp_id=1, expected_power_generation_megawatts=1, target_time=datetime(2022, 1, 1)
         ),
         ForecastValueLatestSQL(
-            gsp_id=1, expected_power_generation_megawatts=2, target_time=datetime(2022, 1, 1, 0, 30)
+            gsp_id=1, expected_power_generation_megawatts=3, target_time=datetime(2022, 1, 1, 1)
         ),
         ForecastValueLatestSQL(
-            gsp_id=1, expected_power_generation_megawatts=3, target_time=datetime(2022, 1, 1, 1)
+            gsp_id=1, expected_power_generation_megawatts=2, target_time=datetime(2022, 1, 1, 0, 30)
         ),
     ]
 
@@ -293,6 +294,7 @@ def test_get_all_gsp_ids_latest_forecast_filter_historic(db_session):
         session=db_session, start_target_time=target_time, historic=True
     )[0]
     assert len(forecast.forecast_values_latest) == 2
+    assert forecast.forecast_values_latest[-1].expected_power_generation_megawatts == 3
 
 
 def test_get_national_latest_forecast(db_session):


### PR DESCRIPTION
# Pull Request

## Description

make sure that target times are sorted

Fixes #

## How Has This Been Tested?

added tests where data is not sorted in the database, this faield before doing the change

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
