### PR TITLE
Add option to run for PV database as well

### DIFF
--- a/nowcasting_datamodel/migrations/app.py
+++ b/nowcasting_datamodel/migrations/app.py
@@ -30,15 +30,7 @@ logger.setLevel(os.getenv("LOGLEVEL", "INFO"))
     type=click.BOOL,
     is_flag=True,
 )
-@click.option(
-    "--run-pv",
-    default=False,
-    envvar="RUN_PV",
-    help="Option to run the database migrations for PV databse as well",
-    type=click.BOOL,
-    is_flag=True,
-)
-def app(make_migrations: bool, run_migrations: bool, run_pv: bool):
+def app(make_migrations: bool, run_migrations: bool):
     """
     Make migrations and run them
 
@@ -52,13 +44,11 @@ def app(make_migrations: bool, run_migrations: bool, run_pv: bool):
 
     if make_migrations:
         make_all_migrations("forecast")
-        if run_pv:
-            make_all_migrations("pv")
+        make_all_migrations("pv")
 
     if run_migrations:
         run_all_migrations("forecast")
-        if run_pv:
-            run_all_migrations("pv")
+        run_all_migrations("pv")
 
 
 def make_all_migrations(database: str):


### PR DESCRIPTION
# Pull Request

## Description

The local infra stack tests fail, see https://github.com/openclimatefix/nowcasting_infrastructure/pull/105 and one of the main issues is that the PV database migrations aren't ran, so all the PV systems tests fail. This fixes that

Fixes #

## How Has This Been Tested?

The tests in https://github.com/openclimatefix/nowcasting_infrastructure/pull/105 show that the PV errors do not exist now after using a custom build of datamodel that runs the PV systems

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
