### PR TITLE
update migrations to be floats, not strings

### DIFF
--- a/nowcasting_datamodel/migrations/forecast/versions/d2f031f24593_.py
+++ b/nowcasting_datamodel/migrations/forecast/versions/d2f031f24593_.py
@@ -22,7 +22,7 @@ def upgrade():  # noqa 103
         sa.Column("created_utc", sa.DateTime(timezone=True), nullable=True),
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("datetime_utc", sa.DateTime(), nullable=True),
-        sa.Column("solar_generation_kw", sa.String(), nullable=True),
+        sa.Column("solar_generation_kw", sa.Float(), nullable=True),
         sa.Column("regime", sa.String(), nullable=True),
         sa.Column("location_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(

--- a/nowcasting_datamodel/migrations/pv/versions/580416fad3df_.py
+++ b/nowcasting_datamodel/migrations/pv/versions/580416fad3df_.py
@@ -36,7 +36,7 @@ def upgrade():  # noqa 103
         sa.Column("created_utc", sa.DateTime(timezone=True), nullable=True),
         sa.Column("id", sa.Integer(), nullable=False),
         sa.Column("datetime_utc", sa.DateTime(), nullable=True),
-        sa.Column("solar_generation_kw", sa.String(), nullable=True),
+        sa.Column("solar_generation_kw", sa.Float(), nullable=True),
         sa.Column("pv_system_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
             ["pv_system_id"],


### PR DESCRIPTION
# Pull Request

## Description

update migrations to make sure solar_genaterion_kw and ... are floats

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
