### PR TITLE
rename to sheffield_solar_passiv

### DIFF
--- a/nowcasting_datamodel/models/pv.py
+++ b/nowcasting_datamodel/models/pv.py
@@ -85,7 +85,7 @@ class PVSystem(EnhancedBaseModel):
             orientation=self.orientation,
             status_interval_minutes=self.status_interval_minutes,
             correct_data=self.correct_data,
-            installed_capacity_kw=self.installed_capacity_kw
+            installed_capacity_kw=self.installed_capacity_kw,
         )
 
 

--- a/tests/read/test_read_pv.py
+++ b/tests/read/test_read_pv.py
@@ -1,7 +1,13 @@
 import logging
 from datetime import datetime
 
-from nowcasting_datamodel.models import PVSystem, PVSystemSQL, PVYield, pv_output, sheffield_solar_passiv
+from nowcasting_datamodel.models import (
+    PVSystem,
+    PVSystemSQL,
+    PVYield,
+    pv_output,
+    sheffield_solar_passiv,
+)
 from nowcasting_datamodel.read.read_pv import get_latest_pv_yield, get_pv_systems, get_pv_yield
 from nowcasting_datamodel.save import save_pv_system
 


### PR DESCRIPTION
# Pull Request

## Description

rename 'solar_sheffield_passiv' to 'sheffield_solar_passiv'

Update:
PVConsumer (and deploy)
Nowcasting_dataset
Nowcasting_forecast  (and deploy)

Update database 'pv_systems' table

Fixes #

## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration_

- [ ] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
