### PR TITLE
add latest forecasts too to fake forecasts, add test

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Functions used to make fake model data.
 
 Tests are run by using the following command
 ```bash
+docker-compose -f test-docker-compose.yml build
 docker-compose -f test-docker-compose.yml run tests
 ```
 

--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -50,6 +50,7 @@ def make_fake_forecast(
     t0_datetime_utc: Optional[datetime] = None,
     forecast_values: Optional = None,
     forecast_values_latest: Optional = None,
+    add_latest: Optional[bool] = False,
 ) -> ForecastSQL:
     """Make one fake forecast"""
     location = get_location(gsp_id=gsp_id, session=session)
@@ -71,10 +72,11 @@ def make_fake_forecast(
 
     if forecast_values_latest is None:
         forecast_values_latest = []
-        for forecast_value in forecast_values:
-            forecast_values_latest.append(change_forecast_value_to_latest(
-                forecast_value, gsp_id=location.gsp_id
-            ))
+        if add_latest:
+            for forecast_value in forecast_values:
+                forecast_values_latest.append(change_forecast_value_to_latest(
+                    forecast_value, gsp_id=location.gsp_id
+                ))
 
     forecast = ForecastSQL(
         model=model,
@@ -93,6 +95,7 @@ def make_fake_forecasts(
     session: Session,
     t0_datetime_utc: Optional[datetime] = None,
     forecast_values: Optional = None,
+    add_latest: Optional[bool] = False
 ) -> List[ForecastSQL]:
     """Make many fake forecast"""
     forecasts = []
@@ -103,6 +106,7 @@ def make_fake_forecasts(
                 t0_datetime_utc=t0_datetime_utc,
                 session=session,
                 forecast_values=forecast_values,
+                add_latest=add_latest
             )
         )
 

--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -69,7 +69,7 @@ def make_fake_forecast(
             forecast_values.append(f)
 
     if forecast_values_latest is None:
-        forecast_values_latest = []
+        forecast_values_latest = forecast_values
 
     forecast = ForecastSQL(
         model=model,
@@ -100,6 +100,8 @@ def make_fake_forecasts(
                 forecast_values=forecast_values,
             )
         )
+
+    session.add_all(forecasts)
 
     return forecasts
 

--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -14,6 +14,7 @@ from nowcasting_datamodel.models import (
 from nowcasting_datamodel.models.forecast import ForecastSQL, ForecastValueSQL
 from nowcasting_datamodel.models.gsp import GSPYieldSQL, LocationSQL
 from nowcasting_datamodel.read.read import get_location, get_model
+from nowcasting_datamodel.update import change_forecast_value_to_latest
 
 # 2 days in the past + 8 hours forward at 30 mins interval
 N_FAKE_FORECASTS = (24 * 2 + 8) * 2
@@ -69,7 +70,11 @@ def make_fake_forecast(
             forecast_values.append(f)
 
     if forecast_values_latest is None:
-        forecast_values_latest = forecast_values
+        forecast_values_latest = []
+        for forecast_value in forecast_values:
+            forecast_values_latest.append(change_forecast_value_to_latest(
+                forecast_value, gsp_id=location.gsp_id
+            ))
 
     forecast = ForecastSQL(
         model=model,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,7 @@ def db_connection():
 
     url = os.getenv("DB_URL", "sqlite:///test.db")
 
-    connection = DatabaseConnection(url=url)
+    connection = DatabaseConnection(url=url, echo=False)
     connection.create_all()
 
     yield connection

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,9 +1,9 @@
 from datetime import datetime, timezone
 
 from nowcasting_datamodel.fake import (
-    make_fake_forecasts,
     make_fake_forecast,
     make_fake_forecast_value,
+    make_fake_forecasts,
     make_fake_gsp_yields,
     make_fake_input_data_last_updated,
     make_fake_location,

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from nowcasting_datamodel.fake import (
+    make_fake_forecasts,
     make_fake_forecast,
     make_fake_forecast_value,
     make_fake_gsp_yields,
@@ -12,6 +13,7 @@ from nowcasting_datamodel.models import (
     Forecast,
     ForecastSQL,
     ForecastValue,
+    ForecastValueLatestSQL,
     GSPYieldSQL,
     InputDataLastUpdated,
     InputDataLastUpdatedSQL,
@@ -54,6 +56,14 @@ def test_make_fake_forecast(db_session):
     db_session.add(f)
     db_session.commit()
     tables = db_session.execute(text("SELECT * FROM forecast_value_2022_01")).all()
+
+
+def test_make_fake_forecasts(db_sessions):
+    make_fake_forecasts(session=db_sessions, gsp_ids=[0, 1, 2, 3])
+
+    assert len(db_sessions.query(ForecastSQL).all()) > 0
+    assert len(db_sessions.query(ForecastValueLatestSQL).all()) > 0
+    assert len(db_sessions.query(ForecastValueSQL).all()) > 0
 
 
 def test_make_national_fake_forecast(db_session):

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -59,7 +59,7 @@ def test_make_fake_forecast(db_session):
 
 
 def test_make_fake_forecasts(db_session):
-    make_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3])
+    make_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=True)
 
     assert len(db_session.query(ForecastSQL).all()) > 0
     assert len(db_session.query(ForecastValueLatestSQL).all()) > 0

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -58,12 +58,12 @@ def test_make_fake_forecast(db_session):
     tables = db_session.execute(text("SELECT * FROM forecast_value_2022_01")).all()
 
 
-def test_make_fake_forecasts(db_sessions):
-    make_fake_forecasts(session=db_sessions, gsp_ids=[0, 1, 2, 3])
+def test_make_fake_forecasts(db_session):
+    make_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3])
 
-    assert len(db_sessions.query(ForecastSQL).all()) > 0
-    assert len(db_sessions.query(ForecastValueLatestSQL).all()) > 0
-    assert len(db_sessions.query(ForecastValueSQL).all()) > 0
+    assert len(db_session.query(ForecastSQL).all()) > 0
+    assert len(db_session.query(ForecastValueLatestSQL).all()) > 0
+    assert len(db_session.query(ForecastValueSQL).all()) > 0
 
 
 def test_make_national_fake_forecast(db_session):


### PR DESCRIPTION
# Pull Request

## Description

make sure `make_fake_forecasts' also makes `forecast_values_latest`

Fixes #

## How Has This Been Tested?

Added test

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
