### PR TITLE
amend fake gsp forecast timedelta to 3 days

### DIFF
--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -189,7 +189,7 @@ def make_fake_gsp_yields_for_one_location(
 
     # make 3 days of fake data
     for i in range(48 * 3):
-        datetime_utc = t0_datetime_utc - timedelta(days=2) + timedelta(minutes=i * 30)
+        datetime_utc = t0_datetime_utc - timedelta(days=3) + timedelta(minutes=i * 30)
         gsp_yield = GSPYieldSQL(
             datetime_utc=datetime_utc,
             solar_generation_kw=np.random.random() * installed_capacity_mw,


### PR DESCRIPTION
# Pull Request

## Description

Amend timedelta on fake gsp forecast generation to correctly offset from 3 days ago up until now.

## How Has This Been Tested?

CI tests

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
