### PR TITLE
add timezone to pv yield

### DIFF
--- a/nowcasting_datamodel/read/read_pv.py
+++ b/nowcasting_datamodel/read/read_pv.py
@@ -103,7 +103,8 @@ def get_latest_pv_yield(
 
     # order by 'created_utc' desc, so we get the latest one
     query = query.order_by(
-        PVSystemSQL.id, desc(PVYieldSQL.datetime_utc), desc(PVYieldSQL.created_utc)
+        PVSystemSQL.id, desc(PVYieldSQL.datetime_utc), desc(
+            PVYieldSQL.created_utc)
     )
 
     # get all results
@@ -111,7 +112,8 @@ def get_latest_pv_yield(
 
     # add utc timezone
     for pv_yield in pv_yields:
-        pv_yield.datetime_utc = pv_yield.datetime_utc.replace(tzinfo=timezone.utc)
+        pv_yield.datetime_utc = pv_yield.datetime_utc.replace(
+            tzinfo=timezone.utc)
 
     if not append_to_pv_systems:
         return pv_yields
@@ -127,9 +129,11 @@ def get_latest_pv_yield(
             pv_systems_with_pv_yields.append(pv_system)
 
         # add pv systems that dont have any pv yields
-        pv_systems_with_pv_yields_ids = [pv_system.id for pv_system in pv_systems_with_pv_yields]
+        pv_systems_with_pv_yields_ids = [
+            pv_system.id for pv_system in pv_systems_with_pv_yields]
 
-        logger.debug(f"Found {len(pv_systems_with_pv_yields_ids)} pv systems with pv yields")
+        logger.debug(
+            f"Found {len(pv_systems_with_pv_yields_ids)} pv systems with pv yields")
 
         pv_systems_with_no_pv_yields = []
         for pv_system in pv_systems:
@@ -138,7 +142,8 @@ def get_latest_pv_yield(
 
                 pv_systems_with_no_pv_yields.append(pv_system)
 
-        logger.debug(f"Found {len(pv_systems_with_no_pv_yields)} pv systems with no pv yields")
+        logger.debug(
+            f"Found {len(pv_systems_with_no_pv_yields)} pv systems with no pv yields")
 
         all_pv_systems = pv_systems_with_pv_yields + pv_systems_with_no_pv_yields
 
@@ -197,5 +202,9 @@ def get_pv_yield(
 
     # get all results
     pv_yields: List[PVYieldSQL] = query.all()
+
+    for pv_yield in pv_yields:
+        pv_yield.datetime_utc = pv_yield.datetime_utc.replace(
+            tzinfo=timezone.utc)
 
     return pv_yields

--- a/nowcasting_datamodel/read/read_pv.py
+++ b/nowcasting_datamodel/read/read_pv.py
@@ -127,13 +127,9 @@ def get_latest_pv_yield(
             pv_systems_with_pv_yields.append(pv_system)
 
         # add pv systems that dont have any pv yields
-        pv_systems_with_pv_yields_ids = [
-            pv_system.id for pv_system in pv_systems_with_pv_yields
-        ]
+        pv_systems_with_pv_yields_ids = [pv_system.id for pv_system in pv_systems_with_pv_yields]
 
-        logger.debug(
-            f"Found {len(pv_systems_with_pv_yields_ids)} pv systems with pv yields"
-        )
+        logger.debug(f"Found {len(pv_systems_with_pv_yields_ids)} pv systems with pv yields")
 
         pv_systems_with_no_pv_yields = []
         for pv_system in pv_systems:
@@ -142,9 +138,7 @@ def get_latest_pv_yield(
 
                 pv_systems_with_no_pv_yields.append(pv_system)
 
-        logger.debug(
-            f"Found {len(pv_systems_with_no_pv_yields)} pv systems with no pv yields"
-        )
+        logger.debug(f"Found {len(pv_systems_with_no_pv_yields)} pv systems with no pv yields")
 
         all_pv_systems = pv_systems_with_pv_yields + pv_systems_with_no_pv_yields
 

--- a/nowcasting_datamodel/read/read_pv.py
+++ b/nowcasting_datamodel/read/read_pv.py
@@ -103,8 +103,7 @@ def get_latest_pv_yield(
 
     # order by 'created_utc' desc, so we get the latest one
     query = query.order_by(
-        PVSystemSQL.id, desc(PVYieldSQL.datetime_utc), desc(
-            PVYieldSQL.created_utc)
+        PVSystemSQL.id, desc(PVYieldSQL.datetime_utc), desc(PVYieldSQL.created_utc)
     )
 
     # get all results
@@ -112,8 +111,7 @@ def get_latest_pv_yield(
 
     # add utc timezone
     for pv_yield in pv_yields:
-        pv_yield.datetime_utc = pv_yield.datetime_utc.replace(
-            tzinfo=timezone.utc)
+        pv_yield.datetime_utc = pv_yield.datetime_utc.replace(tzinfo=timezone.utc)
 
     if not append_to_pv_systems:
         return pv_yields
@@ -130,10 +128,12 @@ def get_latest_pv_yield(
 
         # add pv systems that dont have any pv yields
         pv_systems_with_pv_yields_ids = [
-            pv_system.id for pv_system in pv_systems_with_pv_yields]
+            pv_system.id for pv_system in pv_systems_with_pv_yields
+        ]
 
         logger.debug(
-            f"Found {len(pv_systems_with_pv_yields_ids)} pv systems with pv yields")
+            f"Found {len(pv_systems_with_pv_yields_ids)} pv systems with pv yields"
+        )
 
         pv_systems_with_no_pv_yields = []
         for pv_system in pv_systems:
@@ -143,7 +143,8 @@ def get_latest_pv_yield(
                 pv_systems_with_no_pv_yields.append(pv_system)
 
         logger.debug(
-            f"Found {len(pv_systems_with_no_pv_yields)} pv systems with no pv yields")
+            f"Found {len(pv_systems_with_no_pv_yields)} pv systems with no pv yields"
+        )
 
         all_pv_systems = pv_systems_with_pv_yields + pv_systems_with_no_pv_yields
 
@@ -204,7 +205,6 @@ def get_pv_yield(
     pv_yields: List[PVYieldSQL] = query.all()
 
     for pv_yield in pv_yields:
-        pv_yield.datetime_utc = pv_yield.datetime_utc.replace(
-            tzinfo=timezone.utc)
+        pv_yield.datetime_utc = pv_yield.datetime_utc.replace(tzinfo=timezone.utc)
 
     return pv_yields

--- a/tests/read/test_read_pv.py
+++ b/tests/read/test_read_pv.py
@@ -1,26 +1,15 @@
 import logging
 from datetime import datetime, timezone
 
-from nowcasting_datamodel.models import (
-    PVSystem,
-    PVSystemSQL,
-    pv_output,
-    solar_sheffield_passiv,
-)
-from nowcasting_datamodel.read.read_pv import (
-    get_latest_pv_yield,
-    get_pv_systems,
-    get_pv_yield,
-)
+from nowcasting_datamodel.models import PVSystem, PVSystemSQL, pv_output, solar_sheffield_passiv
+from nowcasting_datamodel.read.read_pv import get_latest_pv_yield, get_pv_systems, get_pv_yield
 from nowcasting_datamodel.save import save_pv_system
 
 logger = logging.getLogger(__name__)
 
 
 def test_save_pv_system(db_session_pv):
-    pv_system_1 = PVSystem(
-        pv_system_id=1, provider="pvoutput.org", status_interval_minutes=5
-    )
+    pv_system_1 = PVSystem(pv_system_id=1, provider="pvoutput.org", status_interval_minutes=5)
 
     save_pv_system(session=db_session_pv, pv_system=pv_system_1)
 
@@ -55,9 +44,7 @@ def test_get_pv_system(db_session_pv, pv_systems):
     pv_systems_get = get_pv_systems(session=db_session_pv)
     assert len(pv_systems_get) == 2
 
-    pv_systems_get = get_pv_systems(
-        session=db_session_pv, pv_systems_ids=[pv_systems_get[0].id]
-    )
+    pv_systems_get = get_pv_systems(session=db_session_pv, pv_systems_ids=[pv_systems_get[0].id])
 
     assert len(pv_systems_get) == 1
 
@@ -76,9 +63,7 @@ def test_get_latest_pv_yield(db_session_pv, pv_yields_and_systems):
     assert pv_yields[0].datetime_utc == datetime(2022, 1, 2, tzinfo=timezone.utc)
     assert pv_yields[1].datetime_utc == datetime(2022, 1, 1, tzinfo=timezone.utc)
 
-    pv_systems = (
-        db_session_pv.query(PVSystemSQL).order_by(PVSystemSQL.created_utc).all()
-    )
+    pv_systems = db_session_pv.query(PVSystemSQL).order_by(PVSystemSQL.created_utc).all()
     pv_yields[0].pv_system.id = pv_systems[0].id
 
 
@@ -112,9 +97,7 @@ def test_get_latest_pv_yield_filter(db_session_pv, pv_yields_and_systems):
 
     assert pv_yields[0].datetime_utc == datetime(2022, 1, 2, tzinfo=timezone.utc)
 
-    pv_systems = (
-        db_session_pv.query(PVSystemSQL).order_by(PVSystemSQL.created_utc).all()
-    )
+    pv_systems = db_session_pv.query(PVSystemSQL).order_by(PVSystemSQL.created_utc).all()
     pv_yields[0].pv_system.id = pv_systems[0].id
 
 
@@ -155,27 +138,14 @@ def test_read_pv_yield(db_session_pv, pv_yields_and_systems):
 
 def test_read_pv_yield_providers(db_session_pv, pv_yields_and_systems):
     assert len(get_pv_yield(session=db_session_pv, providers=[pv_output])) == 3
-    assert (
-        len(get_pv_yield(session=db_session_pv, providers=[solar_sheffield_passiv]))
-        == 0
-    )
+    assert len(get_pv_yield(session=db_session_pv, providers=[solar_sheffield_passiv])) == 0
 
 
 def test_read_pv_yield_correct_data(db_session_pv, pv_yields_and_systems):
     pv_yields_and_systems["pv_systems"][0].correct_data = False
 
-    assert (
-        len(get_pv_yield(session=db_session_pv, pv_systems_ids=[1], correct_data=True))
-        == 0
-    )
-    assert (
-        len(
-            get_pv_yield(
-                session=db_session_pv, pv_systems_ids=[1, 2], correct_data=True
-            )
-        )
-        == 1
-    )
+    assert len(get_pv_yield(session=db_session_pv, pv_systems_ids=[1], correct_data=True)) == 0
+    assert len(get_pv_yield(session=db_session_pv, pv_systems_ids=[1, 2], correct_data=True)) == 1
 
 
 def test_read_pv_yield_start_utc(db_session_pv, pv_yields_and_systems):


### PR DESCRIPTION
# Pull Request

## Description

This pull request is for issue #127: Make sure pv yield has timezone added to it. Adds timezone to PV yields when calling the `get_pv_yield` function.



Fixes #

## How Has This Been Tested?

Ran unit tests as described in the readme. All tests passed succesfully.

- [x] Yes


## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
