### PR TITLE
Add timezones to forecast value creation datetimes

### DIFF
--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -172,6 +172,9 @@ def get_latest_forecast(
 
     logger.debug(f"Found forecasts for gsp id: {gsp_id} {historic=} {forecast=}")
 
+    for forecast_value in forecast.forecast_values:
+        forecast_value.created_utc = forecast_value.created_utc.replace(tzinfo=timezone.utc)
+
     return forecast
 
 
@@ -318,6 +321,12 @@ def get_latest_forecast_for_gsps(
 
     forecasts = sort_all_forecast_value(forecasts)
 
+    # add utc timezone
+    for forecast in forecasts:
+        forecast.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
+        for forecast_value in forecast.forecast_values:
+            forecast_value.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
+
     return forecasts
 
 
@@ -430,6 +439,10 @@ def get_forecast_values(
 
     # get all results
     forecasts = query.all()
+
+    # add utc timezone
+    for forecast in forecasts:
+        forecast.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
 
     return forecasts
 

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -484,6 +484,9 @@ def get_forecast_values_latest(
     # get all results
     forecast_values_latest = query.all()
 
+    for forecast_value in forecast_values_latest:
+        forecast_value.created_utc = forecast_value.created_utc.replace(tzinfo=timezone.utc)
+
     return forecast_values_latest
 
 


### PR DESCRIPTION
# Pull Request

## Description

This PR adds UTC timezones to the `created_utc` attributes of the returned forecast values, as discussed in [this issue](https://github.com/openclimatefix/nowcasting_datamodel/issues/128). No additional dependencies are required.

## How Has This Been Tested?
Standard unit tests have been run.
- [x] Yes

Previous similar PR's haven't added any further logic to the unit tests, but would be happy to add some if required.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
