### PR TITLE
Issue/read end

### DIFF
--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -404,6 +404,7 @@ def get_forecast_values(
     gsp_id: Optional[int] = None,
     gsp_ids: Optional[List[int]] = None,
     start_datetime: Optional[datetime] = None,
+    end_datetime: Optional[datetime] = None,
     forecast_horizon_minutes: Optional[int] = None,
     only_return_latest: Optional[bool] = False,
     model: Optional = ForecastValueSQL,
@@ -419,6 +420,8 @@ def get_forecast_values(
     :param gsp_ids: optional to provide multiple gsp id, to filter query on
         If None is given then all are returned.
     :param start_datetime: optional to filterer target_time by start_datetime
+        If None is given then all are returned.
+    :param end_datetime: optional to filterer target_time by end_datetime
         If None is given then all are returned.
     :param only_return_latest: Optional to only return the latest forecast, not all of them.
         Default is False
@@ -463,6 +466,9 @@ def get_forecast_values(
         created_utc_filter = start_datetime - timedelta(days=1)
         query = query.filter(model.created_utc >= created_utc_filter)
         query = query.filter(ForecastSQL.created_utc >= created_utc_filter)
+
+    if end_datetime is not None:
+        query = query.filter(model.target_time <= end_datetime)
 
     if created_utc_limit is not None:
         query = query.filter(model.created_utc <= created_utc_limit)

--- a/tests/read/test_read_forecast_horizon.py
+++ b/tests/read/test_read_forecast_horizon.py
@@ -59,8 +59,11 @@ def test_get_latest_forecast__with_end_datetime(db_session):
     db_session.commit()
 
     forecast_values = get_forecast_values(
-        session=db_session, forecast_horizon_minutes=120, gsp_id=1, only_return_latest=True,
-        end_datetime=datetime(2023, 1, 1, 13, tzinfo=timezone.utc)
+        session=db_session,
+        forecast_horizon_minutes=120,
+        gsp_id=1,
+        only_return_latest=True,
+        end_datetime=datetime(2023, 1, 1, 13, tzinfo=timezone.utc),
     )
     assert len(forecast_values) == 3
     assert forecast_values[0].created_utc == datetime(2023, 1, 1, 10, tzinfo=timezone.utc)

--- a/tests/read/test_read_forecast_horizon.py
+++ b/tests/read/test_read_forecast_horizon.py
@@ -43,6 +43,31 @@ def test_get_latest_forecast_created_utc_gsp(db_session):
 
 
 @freeze_time("2023-01-01 12:00:00")
+def test_get_latest_forecast__with_end_datetime(db_session):
+    t0_datetime_utc = datetime(2023, 1, 1, 12, tzinfo=timezone.utc)
+
+    f1 = make_fake_forecast(gsp_id=1, session=db_session, t0_datetime_utc=t0_datetime_utc)
+    f2 = make_fake_forecast(gsp_id=1, session=db_session, t0_datetime_utc=t0_datetime_utc)
+
+    for i in range(len(f1.forecast_values)):
+        f1.forecast_values[i].created_utc = datetime(2023, 1, 1, 10, tzinfo=timezone.utc)
+
+    for i in range(len(f2.forecast_values)):
+        f2.forecast_values[i].created_utc = datetime(2023, 1, 1, 12, tzinfo=timezone.utc)
+
+    db_session.add_all([f1, f2])
+    db_session.commit()
+
+    forecast_values = get_forecast_values(
+        session=db_session, forecast_horizon_minutes=120, gsp_id=1, only_return_latest=True,
+        end_datetime=datetime(2023, 1, 1, 13, tzinfo=timezone.utc)
+    )
+    assert len(forecast_values) == 3
+    assert forecast_values[0].created_utc == datetime(2023, 1, 1, 10, tzinfo=timezone.utc)
+    assert forecast_values[0].target_time == datetime(2023, 1, 1, 12, tzinfo=timezone.utc)
+
+
+@freeze_time("2023-01-01 12:00:00")
 def test_get_latest_forecast_created_utc_multi_gsp(db_session):
     t0_datetime_utc = datetime(2023, 1, 1, 12, tzinfo=timezone.utc)
 


### PR DESCRIPTION
# Pull Request

## Description

add filter on end_datetime when getting forecast values
This is useful for analysis dashbaord

## How Has This Been Tested?

added a test

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
