### PR TITLE
update location field in metric value class

### DIFF
--- a/nowcasting_datamodel/models/metric.py
+++ b/nowcasting_datamodel/models/metric.py
@@ -169,7 +169,7 @@ class MetricValue(EnhancedBaseModel):
     datetime_interval: DatetimeInterval = Field(
         ..., description="The datetime interval this value is about"
     )
-    location: Location = Field(..., description="The location object for this metric value")
+    location: Location = Field(None, description="The location object for this metric value")
 
     rm_mode: ClassVar[bool] = True
 


### PR DESCRIPTION
# Pull Request

## Description

In order to get a value for `Daily Latest MAE All GSPs` from the `metric_value` table in the database, the `MetricValue` class in the datamodel needed the `location` field to be updated with `None` instead of `...`. 

This has been updated.

Fixes # => As this is a quick fix, I didn't make an issue for this. 

## How Has This Been Tested?

I ran the Docker tests and they passed. 

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
