### PR TITLE
add function to get latest gsp capacities + test

### DIFF
--- a/nowcasting_datamodel/read/read_gsp.py
+++ b/nowcasting_datamodel/read/read_gsp.py
@@ -305,10 +305,10 @@ def get_latest_gsp_capacities(session: Session, gsp_ids: List[int]) -> pd.Series
     :return: pd.Series with gsp capacities, gsp_ids as the index
     """
 
-    gsp_yields, locations = get_latest_gsp_yield(session=session, gsps=gsp_ids)
+    gsp_yields = get_latest_gsp_yield(session=session, gsps=gsp_ids)
 
     # format results
     eff_capacities = [gsp_yield.capacity_mwp for gsp_yield in gsp_yields]
-    gsp_ids_from_db = [location.gsp_id for location in locations]
+    gsp_ids_from_db = [gsp_yield.location.gsp_id for gsp_yield in gsp_yields]
 
     return pd.Series(eff_capacities, index=gsp_ids_from_db)

--- a/nowcasting_datamodel/read/read_gsp.py
+++ b/nowcasting_datamodel/read/read_gsp.py
@@ -312,5 +312,3 @@ def get_latest_gsp_capacities(session: Session, gsp_ids: List[int]) -> pd.Series
     gsp_ids_from_db = [location.gsp_id for location in locations]
 
     return pd.Series(eff_capacities, index=gsp_ids_from_db)
-
-

--- a/nowcasting_datamodel/read/read_gsp.py
+++ b/nowcasting_datamodel/read/read_gsp.py
@@ -3,6 +3,7 @@ import logging
 from datetime import datetime, timezone
 from typing import List, Optional, Union
 
+import pandas as pd
 from sqlalchemy import desc, func
 from sqlalchemy.orm import Session, contains_eager, joinedload
 
@@ -13,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 def get_latest_gsp_yield(
     session: Session,
-    gsps: List[LocationSQL],
+    gsps: Union[List[LocationSQL], List[int]],
     append_to_gsps: bool = False,
     regime: str = "in-day",
     datetime_utc: Optional[datetime] = None,
@@ -30,7 +31,10 @@ def get_latest_gsp_yield(
     :return: either list of gsp yields, or pv systems
     """
 
-    gsp_ids = [gsp.gsp_id for gsp in gsps]
+    if isinstance(gsps[0], int):
+        gsp_ids = gsps
+    else:
+        gsp_ids = [gsp.gsp_id for gsp in gsps]
 
     # start main query
     query = session.query(GSPYieldSQL)
@@ -290,3 +294,23 @@ def get_gsp_yield_sum(
     ]
 
     return results
+
+
+def get_latest_gsp_capacities(session: Session, gsp_ids: List[int]) -> pd.Series:
+    """
+    Get the latest gsp capacities.
+
+    :param session: database sessions
+    :param gsp_ids: list of gsp_ids
+    :return: pd.Series with gsp capacities, gsp_ids as the index
+    """
+
+    gsp_yields, locations = get_latest_gsp_yield(session=session, gsps=gsp_ids)
+
+    # format results
+    eff_capacities = [gsp_yield.capacity_mwp for gsp_yield in gsp_yields]
+    gsp_ids_from_db = [location.gsp_id for location in locations]
+
+    return pd.Series(eff_capacities, index=gsp_ids_from_db)
+
+

--- a/tests/read/test_read_gsp.py
+++ b/tests/read/test_read_gsp.py
@@ -22,7 +22,7 @@ def setup_gsp_yields(db_session):
     gsp_yield_2 = GSPYield(datetime_utc=datetime(2022, 1, 1), solar_generation_kw=2, capacity_mwp=2)
     gsp_yield_2_sql = gsp_yield_2.to_orm()
 
-    gsp_yield_3 = GSPYield(datetime_utc=datetime(2022, 1, 1), solar_generation_kw=2,capacity_mwp=3)
+    gsp_yield_3 = GSPYield(datetime_utc=datetime(2022, 1, 1), solar_generation_kw=2, capacity_mwp=3)
     gsp_yield_3_sql = gsp_yield_3.to_orm()
 
     gsp_sql_1: LocationSQL = Location(gsp_id=1, label="GSP_1", status_interval_minutes=5).to_orm()

--- a/tests/read/test_read_gsp.py
+++ b/tests/read/test_read_gsp.py
@@ -9,19 +9,20 @@ from nowcasting_datamodel.read.read_gsp import (
     get_gsp_yield_by_location,
     get_latest_gsp_yield,
     get_gsp_yield_sum,
+    get_latest_gsp_capacities,
 )
 
 logger = logging.getLogger(__name__)
 
 
 def setup_gsp_yields(db_session):
-    gsp_yield_1 = GSPYield(datetime_utc=datetime(2022, 1, 2), solar_generation_kw=1)
+    gsp_yield_1 = GSPYield(datetime_utc=datetime(2022, 1, 2), solar_generation_kw=1, capacity_mwp=1)
     gsp_yield_1_sql = gsp_yield_1.to_orm()
 
-    gsp_yield_2 = GSPYield(datetime_utc=datetime(2022, 1, 1), solar_generation_kw=2)
+    gsp_yield_2 = GSPYield(datetime_utc=datetime(2022, 1, 1), solar_generation_kw=2, capacity_mwp=2)
     gsp_yield_2_sql = gsp_yield_2.to_orm()
 
-    gsp_yield_3 = GSPYield(datetime_utc=datetime(2022, 1, 1), solar_generation_kw=2)
+    gsp_yield_3 = GSPYield(datetime_utc=datetime(2022, 1, 1), solar_generation_kw=2,capacity_mwp=3)
     gsp_yield_3_sql = gsp_yield_3.to_orm()
 
     gsp_sql_1: LocationSQL = Location(gsp_id=1, label="GSP_1", status_interval_minutes=5).to_orm()
@@ -241,3 +242,18 @@ def test_get_gsp_yield_sum(db_session):
         gsp_yields[0].solar_generation_kw == 4
     )  # 2+2, see hard coded values in 'setup_gsp_yields'
     assert gsp_yields[1].solar_generation_kw == 1  # 1, see hard coded values in 'setup_gsp_yields'
+
+
+def test_get_latest_gsp_capacities(db_session):
+    _ = setup_gsp_yields(db_session)
+
+    gsp_capacities = get_latest_gsp_capacities(session=db_session, gsp_ids=[1, 2])
+
+    assert len(gsp_capacities) == 2
+    assert gsp_capacities.index[0] == 1
+    assert gsp_capacities.index[1] == 2
+    assert gsp_capacities[1] == 2
+    assert gsp_capacities[1] == 3
+
+    gsp_capacities = get_latest_gsp_capacities(session=db_session, gsp_ids=[1])
+    assert len(gsp_capacities) == 1

--- a/tests/read/test_read_gsp.py
+++ b/tests/read/test_read_gsp.py
@@ -252,8 +252,12 @@ def test_get_latest_gsp_capacities(db_session):
     assert len(gsp_capacities) == 2
     assert gsp_capacities.index[0] == 1
     assert gsp_capacities.index[1] == 2
-    assert gsp_capacities[1] == 2
-    assert gsp_capacities[1] == 3
+    assert gsp_capacities[1] == 1
+    assert gsp_capacities[2] == 3
 
-    gsp_capacities = get_latest_gsp_capacities(session=db_session, gsp_ids=[1])
+
+def test_get_latest_gsp_capacities_one(db_session):
+    _ = setup_gsp_yields(db_session)
+
+    gsp_capacities = get_latest_gsp_capacities(session=db_session, gsp_ids=[2])
     assert len(gsp_capacities) == 1


### PR DESCRIPTION
# Pull Request

## Description

added a function to get the latest gsp capacities from the db. 
This is useful if PVlive goes down, but the we can still use the latest gsp capacites

Helps with https://github.com/openclimatefix/pvnet_app/issues/22

## How Has This Been Tested?

CI Tests + added tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
