### PR TITLE
add 20% restrict on adjust value

### DIFF
--- a/nowcasting_datamodel/save/adjust.py
+++ b/nowcasting_datamodel/save/adjust.py
@@ -1,7 +1,7 @@
 """ Methods for adding adjust values to the forecast"""
 import logging
 from datetime import datetime, timedelta
-from typing import List, Union, Optional
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -14,7 +14,11 @@ logger = logging.getLogger()
 MAX_ADJUST_PER = 0.2
 
 
-def add_adjust_to_forecasts(forecasts_sql: List[ForecastSQL], session, max_adjust_percentage: Optional[float] = MAX_ADJUST_PER):
+def add_adjust_to_forecasts(
+    forecasts_sql: List[ForecastSQL],
+    session,
+    max_adjust_percentage: Optional[float] = MAX_ADJUST_PER,
+):
     """
     Adjust National Forecast by ME over the last week
 
@@ -32,10 +36,14 @@ def add_adjust_to_forecasts(forecasts_sql: List[ForecastSQL], session, max_adjus
     if len(forecast_national) != 1:
         logger.debug("Could not find single national forecast, tehre fore not adding adjust")
 
-    add_adjust_to_national_forecast(forecast=forecast_national[0], session=session, max_adjust_percentage=max_adjust_percentage)
+    add_adjust_to_national_forecast(
+        forecast=forecast_national[0], session=session, max_adjust_percentage=max_adjust_percentage
+    )
 
 
-def add_adjust_to_national_forecast(forecast: ForecastSQL, session, max_adjust_percentage: Optional[float] = MAX_ADJUST_PER):
+def add_adjust_to_national_forecast(
+    forecast: ForecastSQL, session, max_adjust_percentage: Optional[float] = MAX_ADJUST_PER
+):
     """
     Add adjust to national forecast.
 
@@ -91,7 +99,9 @@ def add_adjust_to_national_forecast(forecast: ForecastSQL, session, max_adjust_p
             # also, if the forecast value is 0, then adjust value should also be 0
             if max_adjust_percentage is not None:
                 if forecast_value.expected_power_generation_megawatts != 0:
-                    max_adjust = max_adjust_percentage * forecast_value.expected_power_generation_megawatts
+                    max_adjust = (
+                        max_adjust_percentage * forecast_value.expected_power_generation_megawatts
+                    )
                     if value > max_adjust:
                         value = max_adjust
                     elif value < -max_adjust:

--- a/nowcasting_datamodel/save/adjust.py
+++ b/nowcasting_datamodel/save/adjust.py
@@ -26,7 +26,8 @@ def add_adjust_to_forecasts(
 
     :param forecasts_sql: list of forecasts
     :param session: database sessions
-    :param max_adjust_percentage: maximum percentage of forecast value that can be adjusted. If this is None, then no limit is used
+    :param max_adjust_percentage: maximum percentage of forecast value that can be adjusted.
+        If this is None, then no limit is used
     """
     logger.debug("Adding Adjusts to National forecast")
 
@@ -54,7 +55,8 @@ def add_adjust_to_national_forecast(
 
     :param forecast: national forecast
     :param session:
-    :param max_adjust_percentage: maximum percentage of forecast value that can be adjusted. If this is None, then no limit is used
+    :param max_adjust_percentage: maximum percentage of forecast value that can be adjusted.
+        If this is None, then no limit is used
 
     :return:
     """
@@ -93,7 +95,7 @@ def add_adjust_to_national_forecast(
             value = latest_me_df[latest_me_df["datetime"] == forecast_value.target_time]
             value = value.iloc[0].value
 
-            # reduce adjust value by at most 20% of forecast_value.expected_power_generation_megawatts,
+            # reduce adjust value by at most 20% of expected_power_generation_megawatts,
             # if the forecast_value is not 0
             # note that adjust value can be negative, so we need to be careful
             # also, if the forecast value is 0, then adjust value should also be 0

--- a/tests/models/test_convert.py
+++ b/tests/models/test_convert.py
@@ -10,7 +10,10 @@ from nowcasting_datamodel.models.convert import (
 )
 from nowcasting_datamodel.save.save import save_all_forecast_values_seven_days
 
+from freezegun import freeze_time
 
+
+@freeze_time("2023-01-09 16:25")
 def test_convert_list_forecast_value_seven_days_sql_to_list_forecast(db_session):
     # set up
     forecasts = make_fake_forecasts(gsp_ids=range(0, 10), session=db_session)


### PR DESCRIPTION
# Pull Request

## Description

Update the adjust mw value to
- be 0 if the forecast value is 0
- restrict to 20% of forecast_value

## How Has This Been Tested?

Added tests

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
