### PR TITLE
Create ForecastValueYearMonth with factory function to avoid warning message

### DIFF
--- a/nowcasting_datamodel/models/forecast.py
+++ b/nowcasting_datamodel/models/forecast.py
@@ -184,15 +184,18 @@ def get_partitions(start_year: int, start_month: int, end_year: int, end_month: 
     return partitions
 
 
-def create_forecastvalueyearmonth_class(year, month): 
+def create_forecastvalueyearmonth_class(year, month):
     """Dynamically create a ForecastValueYearMonthClass dynamically for input year and month"""
-    
+
     ForecastValueYearMonthClass = type(
-        f"ForecastValueY{year}M{month}", 
-        (ForecastValueSQLMixin, Base_Forecast,),
-        dict( 
-            __tablename__ = f"forecast_value_{year}_{month}",
-            __table_args__ = (
+        f"ForecastValueY{year}M{month}",
+        (
+            ForecastValueSQLMixin,
+            Base_Forecast,
+        ),
+        dict(
+            __tablename__=f"forecast_value_{year}_{month}",
+            __table_args__=(
                 Index(
                     f"forecast_value_{year}_{month}_created_utc_idx",  # Index name
                     "created_utc",  # Columns which are part of the index
@@ -205,9 +208,9 @@ def create_forecastvalueyearmonth_class(year, month):
                     f"forecast_value_{year}_{month}_forecast_id_idx",  # Index name
                     "forecast_id",  # Columns which are part of the index
                 ),
-            )
-        )
-    ) 
+            ),
+        ),
+    )
     return ForecastValueYearMonthClass
 
 

--- a/nowcasting_datamodel/models/forecast.py
+++ b/nowcasting_datamodel/models/forecast.py
@@ -184,6 +184,33 @@ def get_partitions(start_year: int, start_month: int, end_year: int, end_month: 
     return partitions
 
 
+def create_forecastvalueyearmonth_class(year, month): 
+    """Dynamically create a ForecastValueYearMonthClass dynamically for input year and month"""
+    
+    ForecastValueYearMonthClass = type(
+        f"ForecastValueY{year}M{month}", 
+        (ForecastValueSQLMixin, Base_Forecast,),
+        dict( 
+            __tablename__ = f"forecast_value_{year}_{month}",
+            __table_args__ = (
+                Index(
+                    f"forecast_value_{year}_{month}_created_utc_idx",  # Index name
+                    "created_utc",  # Columns which are part of the index
+                ),
+                Index(
+                    f"forecast_value_{year}_{month}_target_time_idx",  # Index name
+                    "target_time",  # Columns which are part of the index
+                ),
+                Index(
+                    f"forecast_value_{year}_{month}_forecast_id_idx",  # Index name
+                    "forecast_id",  # Columns which are part of the index
+                ),
+            )
+        )
+    ) 
+    return ForecastValueYearMonthClass
+
+
 def make_partitions(start_year: int, start_month: int, end_year: int):
     """
     Make partitions
@@ -209,23 +236,8 @@ def make_partitions(start_year: int, start_month: int, end_year: int):
             if month_end < 10:
                 month_end = f"0{month_end}"
 
-            class ForecastValueYearMonth(ForecastValueSQLMixin, Base_Forecast):
-                __tablename__ = f"forecast_value_{year}_{month}"
-
-                __table_args__ = (
-                    Index(
-                        f"forecast_value_{year}_{month}_created_utc_idx",  # Index name
-                        "created_utc",  # Columns which are part of the index
-                    ),
-                    Index(
-                        f"forecast_value_{year}_{month}_target_time_idx",  # Index name
-                        "target_time",  # Columns which are part of the index
-                    ),
-                    Index(
-                        f"forecast_value_{year}_{month}_forecast_id_idx",  # Index name
-                        "forecast_id",  # Columns which are part of the index
-                    ),
-                )
+            # Dynamically create class
+            ForecastValueYearMonth = create_forecastvalueyearmonth_class(year, month)
 
             ForecastValueYearMonth.__table__.add_is_dependent_on(ForecastValueSQL.__table__)
 


### PR DESCRIPTION
The way the ForecastValueYearMonth classes are created for each year and month currently causes a warning message when this library is imported like:

```
warnings.warn(message, UserWarning)
.../nowcasting_datamodel/models/forecast.py:212: SAWarning: This declarative base already contains a class 
with the same class name and module name as nowcasting_datamodel.models.forecast.ForecastValueYearMonth, 
and will be replaced in the string-lookup table.
```

This pull request creates the classes dynamically and should remove the warning message since the class names are distinct for each year and month

Closes #148

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
