### PR TITLE
store the model and weight information as a JSON/dict field

### DIFF
--- a/nowcasting_datamodel/models/forecast.py
+++ b/nowcasting_datamodel/models/forecast.py
@@ -152,6 +152,9 @@ class ForecastValueSQL(
 
     forecast = relationship("ForecastSQL", back_populates="forecast_values")
 
+    # Store the model and weight information as a JSON/dict field
+    model_info = Column(MutableDict.as_mutable(JSON), nullable=True)
+
 
 def get_partitions(start_year: int, start_month: int, end_year: int, end_month: int):
     """Make partitions"""
@@ -339,6 +342,9 @@ class ForecastValue(EnhancedBaseModel):
     )
 
     _normalize_target_time = validator("target_time", allow_reuse=True)(datetime_must_have_timezone)
+
+    # Store the model and weight information as a JSON/dict field
+    _model_info: Optional[dict] = PrivateAttr(None)
 
     def to_orm(self) -> ForecastValueSQL:
         """Change model to ForecastValueSQL"""

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -461,7 +461,7 @@ def get_forecast_values(
         ForecastValueSevenDaysSQL.__tablename__,
         ForecastValueSQL.__tablename__,
     ]
-    query = session.query(model)
+    query = session.query(model, model.model_info)
 
     # make distinct and order by columns
     order_by_columns = []
@@ -539,7 +539,9 @@ def get_forecast_values(
     # add utc timezone
     for forecast in forecasts:
         forecast.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
-
+        if hasattr(forecast, 'model_info'):
+            forecast.model_info = forecast.model_info or {}
+    
     return forecasts
 
 
@@ -599,7 +601,9 @@ def get_forecast_values_latest(
 
     for forecast_value in forecast_values_latest:
         forecast_value.created_utc = forecast_value.created_utc.replace(tzinfo=timezone.utc)
-
+        if hasattr(forecast_value, 'model_info'):
+            forecast_value.model_info = forecast_value.model_info or {}
+    
     return forecast_values_latest
 
 

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -539,9 +539,9 @@ def get_forecast_values(
     # add utc timezone
     for forecast in forecasts:
         forecast.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
-        if hasattr(forecast, 'model_info'):
+        if hasattr(forecast, "model_info"):
             forecast.model_info = forecast.model_info or {}
-    
+
     return forecasts
 
 
@@ -601,9 +601,9 @@ def get_forecast_values_latest(
 
     for forecast_value in forecast_values_latest:
         forecast_value.created_utc = forecast_value.created_utc.replace(tzinfo=timezone.utc)
-        if hasattr(forecast_value, 'model_info'):
+        if hasattr(forecast_value, "model_info"):
             forecast_value.model_info = forecast_value.model_info or {}
-    
+
     return forecast_values_latest
 
 


### PR DESCRIPTION
# Pull Request

## Description

This will enable saving what models/weights are used for each forecast

Fixes #

this is related to [uk-pv-forecast-blend](https://github.com/openclimatefix/uk-pv-forecast-blend/issues/15)

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have checked my code and corrected any misspellings
