### PR TITLE
Upgrade pydantic validator to field_validator (#281)

### DIFF
--- a/nowcasting_datamodel/models/forecast.py
+++ b/nowcasting_datamodel/models/forecast.py
@@ -11,7 +11,7 @@ from datetime import datetime
 from typing import List, Optional
 
 import numpy as np
-from pydantic import Field, PrivateAttr, validator
+from pydantic import Field, PrivateAttr, field_validator
 from sqlalchemy import (
     JSON,
     Boolean,
@@ -338,8 +338,10 @@ class ForecastValue(EnhancedBaseModel):
         None,
     )
 
-    _normalize_target_time = validator("target_time", allow_reuse=True)(datetime_must_have_timezone)
-
+    @field_validator("target_time", mode="before")
+    def normalize_target_time(cls, v):
+        return datetime_must_have_timezone(cls, v)
+    
     def to_orm(self) -> ForecastValueSQL:
         """Change model to ForecastValueSQL"""
         return ForecastValueSQL(
@@ -476,9 +478,9 @@ class Forecast(EnhancedBaseModel):
         description="Information about the input data that was used to create the forecast",
     )
 
-    _normalize_forecast_creation_time = validator("forecast_creation_time", allow_reuse=True)(
-        datetime_must_have_timezone
-    )
+    @field_validator("forecast_creation_time", mode="before")
+    def normalize_forecast_creation_time(cls, v):
+        return datetime_must_have_timezone(cls, v)
 
     def to_orm(self) -> ForecastSQL:
         """Change model to ForecastSQL"""

--- a/nowcasting_datamodel/models/forecast.py
+++ b/nowcasting_datamodel/models/forecast.py
@@ -340,6 +340,7 @@ class ForecastValue(EnhancedBaseModel):
 
     @field_validator("target_time", mode="before")
     def normalize_target_time(cls, v):
+        """Normalize target_time field"""
         return datetime_must_have_timezone(cls, v)
 
     def to_orm(self) -> ForecastValueSQL:
@@ -480,6 +481,7 @@ class Forecast(EnhancedBaseModel):
 
     @field_validator("forecast_creation_time", mode="before")
     def normalize_forecast_creation_time(cls, v):
+        """Normalize forecast_creation_time field"""
         return datetime_must_have_timezone(cls, v)
 
     def to_orm(self) -> ForecastSQL:

--- a/nowcasting_datamodel/models/forecast.py
+++ b/nowcasting_datamodel/models/forecast.py
@@ -341,7 +341,7 @@ class ForecastValue(EnhancedBaseModel):
     @field_validator("target_time", mode="before")
     def normalize_target_time(cls, v):
         return datetime_must_have_timezone(cls, v)
-    
+
     def to_orm(self) -> ForecastValueSQL:
         """Change model to ForecastValueSQL"""
         return ForecastValueSQL(

--- a/nowcasting_datamodel/models/gsp.py
+++ b/nowcasting_datamodel/models/gsp.py
@@ -111,10 +111,12 @@ class GSPYield(EnhancedBaseModel):
 
     @field_validator("datetime_utc", mode="before")
     def normalize_datetime_utc(cls, v):
+        """Normalize datetime_utc field"""
         return datetime_must_have_timezone(cls, v)
 
     @field_validator("pvlive_updated_utc", mode="before")
     def normalize_pvlive_updated_utc(cls, v):
+        """Normalize pvlive_updated_utc field"""
         return datetime_must_have_timezone(cls, v)
 
     @field_validator("solar_generation_kw")

--- a/nowcasting_datamodel/models/gsp.py
+++ b/nowcasting_datamodel/models/gsp.py
@@ -9,7 +9,7 @@ import logging
 from datetime import datetime
 from typing import ClassVar, List, Optional
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 from sqlalchemy import Column, DateTime, Float, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import relationship
 
@@ -104,20 +104,20 @@ class GSPYield(EnhancedBaseModel):
     )
     capacity_mwp: Optional[float] = Field(None, description="The estimate current capacity")
     pvlive_updated_utc: Optional[datetime] = Field(None, description="When PVlive made this value")
-
-    _normalize_target_time = validator("datetime_utc", allow_reuse=True)(
-        datetime_must_have_timezone
-    )
-    _normalize_pvlive_updated_utc = validator("pvlive_updated_utc", allow_reuse=True)(
-        datetime_must_have_timezone
-    )
-
     gsp: Optional[Location] = Field(
         None,
         description="The GSP associated with this model",
     )
 
-    @validator("solar_generation_kw")
+    @field_validator("datetime_utc", mode="before")
+    def normalize_datetime_utc(cls, v):
+        return datetime_must_have_timezone(cls, v)
+    
+    @field_validator("pvlive_updated_utc", mode="before")
+    def normalize_pvlive_updated_utc(cls, v):
+        return datetime_must_have_timezone(cls, v)
+
+    @field_validator("solar_generation_kw")
     def validate_solar_generation_kw(cls, v):
         """Validate the solar_generation_kw field"""
         if v < 0:
@@ -125,7 +125,7 @@ class GSPYield(EnhancedBaseModel):
             v = 0
         return v
 
-    @validator("regime")
+    @field_validator("regime")
     def validate_regime(cls, v):
         """Validate the solar_generation_kw field"""
         if v not in ["day-after", "in-day"]:

--- a/nowcasting_datamodel/models/gsp.py
+++ b/nowcasting_datamodel/models/gsp.py
@@ -112,7 +112,7 @@ class GSPYield(EnhancedBaseModel):
     @field_validator("datetime_utc", mode="before")
     def normalize_datetime_utc(cls, v):
         return datetime_must_have_timezone(cls, v)
-    
+
     @field_validator("pvlive_updated_utc", mode="before")
     def normalize_pvlive_updated_utc(cls, v):
         return datetime_must_have_timezone(cls, v)

--- a/nowcasting_datamodel/models/metric.py
+++ b/nowcasting_datamodel/models/metric.py
@@ -105,7 +105,7 @@ class DatetimeInterval(EnhancedBaseModel):
     @field_validator("start_datetime_utc", mode="before")
     def normalize_start_datetime_utc(cls, v):
         return datetime_must_have_timezone(cls, v)
-    
+
     @field_validator("end_datetime_utc", mode="before")
     def normalize_end_datetime_utc(cls, v):
         return datetime_must_have_timezone(cls, v)

--- a/nowcasting_datamodel/models/metric.py
+++ b/nowcasting_datamodel/models/metric.py
@@ -104,10 +104,12 @@ class DatetimeInterval(EnhancedBaseModel):
 
     @field_validator("start_datetime_utc", mode="before")
     def normalize_start_datetime_utc(cls, v):
+        """Normalize start_datetime_utc field"""
         return datetime_must_have_timezone(cls, v)
 
     @field_validator("end_datetime_utc", mode="before")
     def normalize_end_datetime_utc(cls, v):
+        """Normalize end_datetime_utc field"""
         return datetime_must_have_timezone(cls, v)
 
     def to_orm(self) -> DatetimeIntervalSQL:

--- a/nowcasting_datamodel/models/metric.py
+++ b/nowcasting_datamodel/models/metric.py
@@ -10,7 +10,7 @@ The followin tables are made with sqlamyc and pydantic
 from datetime import datetime, time
 from typing import ClassVar, Optional
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String, Time
 from sqlalchemy.orm import relationship
 
@@ -102,12 +102,13 @@ class DatetimeInterval(EnhancedBaseModel):
         None, description="The elexon settlement period. This is optional"
     )
 
-    _normalize_start_datetime_utc = validator("start_datetime_utc", allow_reuse=True)(
-        datetime_must_have_timezone
-    )
-    _normalize_end_datetime_utc = validator("end_datetime_utc", allow_reuse=True)(
-        datetime_must_have_timezone
-    )
+    @field_validator("start_datetime_utc", mode="before")
+    def normalize_start_datetime_utc(cls, v):
+        return datetime_must_have_timezone(cls, v)
+    
+    @field_validator("end_datetime_utc", mode="before")
+    def normalize_end_datetime_utc(cls, v):
+        return datetime_must_have_timezone(cls, v)
 
     def to_orm(self) -> DatetimeIntervalSQL:
         """Change model to GSPYieldSQL"""

--- a/nowcasting_datamodel/models/models.py
+++ b/nowcasting_datamodel/models/models.py
@@ -97,19 +97,19 @@ class InputDataLastUpdated(EnhancedBaseModel):
     @field_validator("gsp", mode="before")
     def normalize_gsp(cls, v):
         return datetime_must_have_timezone(cls, v)
-    
+
     @field_validator("nwp", mode="before")
     def normalize_nwp(cls, v):
         return datetime_must_have_timezone(cls, v)
-    
+
     @field_validator("pv", mode="before")
     def normalize_pv(cls, v):
         return datetime_must_have_timezone(cls, v)
-    
+
     @field_validator("satellite", mode="before")
     def normalize_satellite(cls, v):
         return datetime_must_have_timezone(cls, v)
-    
+
     def to_orm(self) -> InputDataLastUpdatedSQL:
         """Change model to InputDataLastUpdatedSQL"""
         return InputDataLastUpdatedSQL(

--- a/nowcasting_datamodel/models/models.py
+++ b/nowcasting_datamodel/models/models.py
@@ -96,18 +96,22 @@ class InputDataLastUpdated(EnhancedBaseModel):
 
     @field_validator("gsp", mode="before")
     def normalize_gsp(cls, v):
+        """Normalize gsp field"""
         return datetime_must_have_timezone(cls, v)
 
     @field_validator("nwp", mode="before")
     def normalize_nwp(cls, v):
+        """Normalize nwp field"""
         return datetime_must_have_timezone(cls, v)
 
     @field_validator("pv", mode="before")
     def normalize_pv(cls, v):
+        """Normalize pv field"""
         return datetime_must_have_timezone(cls, v)
 
     @field_validator("satellite", mode="before")
     def normalize_satellite(cls, v):
+        """Normalize satellite field"""
         return datetime_must_have_timezone(cls, v)
 
     def to_orm(self) -> InputDataLastUpdatedSQL:

--- a/nowcasting_datamodel/models/models.py
+++ b/nowcasting_datamodel/models/models.py
@@ -13,7 +13,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 from sqlalchemy import Column, DateTime, Index, Integer, String
 from sqlalchemy.orm import relationship
 
@@ -94,11 +94,22 @@ class InputDataLastUpdated(EnhancedBaseModel):
         ..., description="The time when the input satellite data was last updated"
     )
 
-    _normalize_gsp = validator("gsp", allow_reuse=True)(datetime_must_have_timezone)
-    _normalize_nwp = validator("nwp", allow_reuse=True)(datetime_must_have_timezone)
-    _normalize_pv = validator("pv", allow_reuse=True)(datetime_must_have_timezone)
-    _normalize_satellite = validator("satellite", allow_reuse=True)(datetime_must_have_timezone)
-
+    @field_validator("gsp", mode="before")
+    def normalize_gsp(cls, v):
+        return datetime_must_have_timezone(cls, v)
+    
+    @field_validator("nwp", mode="before")
+    def normalize_nwp(cls, v):
+        return datetime_must_have_timezone(cls, v)
+    
+    @field_validator("pv", mode="before")
+    def normalize_pv(cls, v):
+        return datetime_must_have_timezone(cls, v)
+    
+    @field_validator("satellite", mode="before")
+    def normalize_satellite(cls, v):
+        return datetime_must_have_timezone(cls, v)
+    
     def to_orm(self) -> InputDataLastUpdatedSQL:
         """Change model to InputDataLastUpdatedSQL"""
         return InputDataLastUpdatedSQL(
@@ -134,7 +145,7 @@ class Status(EnhancedBaseModel):
         """Change model to SQL"""
         return StatusSQL(status=self.status, message=self.message)
 
-    @validator("status")
+    @field_validator("status")
     def validate_solar_generation_kw(cls, v):
         """Validate the solar_generation_kw field"""
         if v not in ["ok", "warning", "error"]:

--- a/nowcasting_datamodel/models/pv.py
+++ b/nowcasting_datamodel/models/pv.py
@@ -136,6 +136,7 @@ class PVYield(EnhancedBaseModel):
 
     @field_validator("datetime_utc", mode="before")
     def normalize_datetime_utc(cls, v):
+        """Normalize datetime_utc field"""
         return datetime_must_have_timezone(cls, v)
 
     @field_validator("solar_generation_kw")

--- a/nowcasting_datamodel/models/pv.py
+++ b/nowcasting_datamodel/models/pv.py
@@ -9,7 +9,7 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from pydantic import Field, validator
+from pydantic import Field, field_validator
 from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, String
 from sqlalchemy.orm import relationship
 
@@ -79,7 +79,7 @@ class PVSystem(EnhancedBaseModel):
     )
     ocf_id: Optional[int] = Field(None, description="The PV system id that is unique to OCF")
 
-    @validator("provider")
+    @field_validator("provider")
     def validate_provider(cls, v):
         """Validate the provider"""
         if v not in providers:
@@ -129,17 +129,16 @@ class PVYield(EnhancedBaseModel):
 
     datetime_utc: datetime = Field(..., description="The timestamp of the pv system")
     solar_generation_kw: float = Field(..., description="The provider of the PV system")
-
-    _normalize_target_time = validator("datetime_utc", allow_reuse=True)(
-        datetime_must_have_timezone
-    )
-
     pv_system: Optional[PVSystem] = Field(
         None,
         description="The PV system associated with this model",
     )
 
-    @validator("solar_generation_kw")
+    @field_validator("datetime_utc", mode="before")
+    def normalize_datetime_utc(cls, v):
+        return datetime_must_have_timezone(cls, v)
+
+    @field_validator("solar_generation_kw")
     def validate_solar_generation_kw(cls, v):
         """Validate the solar_generation_kw field"""
         if v < 0:


### PR DESCRIPTION
# Pull Request

## Description

This PR refers to the issue #281 : pydantic: Upgrade validator to field_validator

I followed the instructions in the link provided and the recommendations in the Pydantic migration guide.

This lead to the subsequent modifications : 
 - upgraded validator decorators to field_validators decorators
 - modified _normalize_target_time like functions that referred to validator function, to normalize_target_time like functions with field_validator decorations to match pydantic V2 recommendations


## How Has This Been Tested?

I tested via the test framework as seen in the readme file. As the modification are minors, it should be enough.

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation > not needed
- [ ] I have added tests that prove my fix is effective or that my feature works > not needed
- [x] I have checked my code and corrected any misspellings