### PR TITLE
ad option to not save to last_seven_days

### DIFF
--- a/nowcasting_datamodel/save/save.py
+++ b/nowcasting_datamodel/save/save.py
@@ -24,6 +24,7 @@ def save(
     update_national: Optional[bool] = True,
     update_gsp: Optional[bool] = True,
     apply_adjuster: Optional[bool] = True,
+    save_to_last_seven_days: Optional[bool] = True,
 ):
     """
     Save forecast to database
@@ -38,6 +39,7 @@ def save(
     :param update_national: Optional (default true), to update the national forecast
     :param update_gsp: Optional (default true), to update all the GSP forecasts
     :param apply_adjuster: Optional (default true), to apply the adjuster
+    :param save_to_last_seven_days: Optional (default true), to save to the last seven days table
     """
 
     use_adjuster_env_var = bool(os.getenv("USE_ADJUSTER", "True").lower() in ["true", "1"])
@@ -63,9 +65,10 @@ def save(
     )
     session.commit()
 
-    logger.debug("Saving to last seven days table")
-    save_all_forecast_values_seven_days(session=session, forecasts=forecasts)
-    session.commit()
+    if save_to_last_seven_days:
+        logger.debug("Saving to last seven days table")
+        save_all_forecast_values_seven_days(session=session, forecasts=forecasts)
+        session.commit()
 
 
 def save_pv_system(session: Session, pv_system: PVSystem) -> PVSystemSQL:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ alembic
 click
 freezegun
 structlog
+numpy==1.26.4


### PR DESCRIPTION
# Pull Request

## Description
Add option to not save to last seven day forecast value tables

Helps with https://github.com/openclimatefix/pvnet_app/issues/93

## How Has This Been Tested?

CI tests
- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
