### PR TITLE
add datetime_utc into get_latest_gsp_capacities

### DIFF
--- a/nowcasting_datamodel/read/read_gsp.py
+++ b/nowcasting_datamodel/read/read_gsp.py
@@ -297,16 +297,19 @@ def get_gsp_yield_sum(
     return results
 
 
-def get_latest_gsp_capacities(session: Session, gsp_ids: List[int]) -> pd.Series:
+def get_latest_gsp_capacities(
+    session: Session, gsp_ids: List[int], datetime_utc: Optional[datetime] = None
+) -> pd.Series:
     """
     Get the latest gsp capacities.
 
     :param session: database sessions
     :param gsp_ids: list of gsp_ids
+    :param datetime_utc: datetime to filter on
     :return: pd.Series with gsp capacities, gsp_ids as the index
     """
 
-    gsp_yields = get_latest_gsp_yield(session=session, gsps=gsp_ids)
+    gsp_yields = get_latest_gsp_yield(session=session, gsps=gsp_ids, datetime_utc=datetime_utc)
 
     # format results
     eff_capacities = [gsp_yield.capacity_mwp for gsp_yield in gsp_yields]


### PR DESCRIPTION
# Pull Request

## Description

add `datetime_utc` to `get_latest_gsp_capacities`

Helps with https://github.com/openclimatefix/pvnet_app/issues/99

## How Has This Been Tested?

CI tests

- [ ] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
