### PR TITLE
Add URL Filtering Capabilities to API Request Retrieval Functions

### DIFF
--- a/nowcasting_datamodel/read/read_user.py
+++ b/nowcasting_datamodel/read/read_user.py
@@ -1,12 +1,16 @@
 """ Read user"""
+
 import logging
 from datetime import datetime
 from typing import List, Optional
+
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm.session import Session
+
 from nowcasting_datamodel.models.api import APIRequestSQL, UserSQL
 
 logger = logging.getLogger(__name__)
+
 
 def get_user(session: Session, email: str) -> UserSQL:
     """
@@ -30,10 +34,9 @@ def get_user(session: Session, email: str) -> UserSQL:
         user = users[0]
     return user
 
+
 def get_all_last_api_request(
-    session: Session, 
-    include_in_url: Optional[str] = None, 
-    exclude_in_url: Optional[str] = None
+    session: Session, include_in_url: Optional[str] = None, exclude_in_url: Optional[str] = None
 ) -> List[APIRequestSQL]:
     """
     Get all last api requests for all users
@@ -50,15 +53,16 @@ def get_all_last_api_request(
         .populate_existing()
         .order_by(APIRequestSQL.user_uuid, APIRequestSQL.created_utc.desc())
     )
-    
+
     # Apply URL filtering if specified
     if include_in_url is not None:
-        query = query.filter(APIRequestSQL.url.like(f'%{include_in_url}%'))
-    
+        query = query.filter(APIRequestSQL.url.like(f"%{include_in_url}%"))
+
     if exclude_in_url is not None:
-        query = query.filter(~APIRequestSQL.url.like(f'%{exclude_in_url}%'))
-    
+        query = query.filter(~APIRequestSQL.url.like(f"%{exclude_in_url}%"))
+
     return query.all()
+
 
 def get_api_requests_for_one_user(
     session: Session,
@@ -78,18 +82,18 @@ def get_api_requests_for_one_user(
     :param exclude_in_url: Optional filter to exclude URLs containing this string
     """
     query = session.query(APIRequestSQL).join(UserSQL).filter(UserSQL.email == email)
-    
+
     if start_datetime is not None:
         query = query.filter(APIRequestSQL.created_utc >= start_datetime)
-    
+
     if end_datetime is not None:
         query = query.filter(APIRequestSQL.created_utc <= end_datetime)
-    
+
     # Apply URL filtering if specified
     if include_in_url is not None:
-        query = query.filter(APIRequestSQL.url.like(f'%{include_in_url}%'))
-    
+        query = query.filter(APIRequestSQL.url.like(f"%{include_in_url}%"))
+
     if exclude_in_url is not None:
-        query = query.filter(~APIRequestSQL.url.like(f'%{exclude_in_url}%'))
-    
+        query = query.filter(~APIRequestSQL.url.like(f"%{exclude_in_url}%"))
+
     return query.order_by(APIRequestSQL.created_utc.desc()).all()

--- a/nowcasting_datamodel/read/read_user.py
+++ b/nowcasting_datamodel/read/read_user.py
@@ -1,95 +1,95 @@
 """ Read user"""
-
 import logging
 from datetime import datetime
 from typing import List, Optional
-
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm.session import Session
-
 from nowcasting_datamodel.models.api import APIRequestSQL, UserSQL
 
 logger = logging.getLogger(__name__)
 
-
 def get_user(session: Session, email: str) -> UserSQL:
     """
     Get metric object from database
-
     :param session: database session
     :param email: email of user
-
     return: One Metric SQl object
-
     """
-
     # start main query
     query = session.query(UserSQL)
-
     # filter on name
     query = query.filter(UserSQL.email == email)
-
     # get all results
     users = query.all()
-
     if len(users) == 0:
         logger.debug(f"User for name {email} does not exist so going to add it")
-
         user = UserSQL(email=email)
-
         session.add(user)
         session.commit()
-
     else:
         user = users[0]
-
     return user
 
-
-def get_all_last_api_request(session: Session) -> List[APIRequestSQL]:
+def get_all_last_api_request(
+    session: Session, 
+    include_in_url: Optional[str] = None, 
+    exclude_in_url: Optional[str] = None
+) -> List[APIRequestSQL]:
     """
     Get all last api requests for all users
-
     :param session: database session
-    :return:
+    :param include_in_url: Optional filter to include only URLs containing this string
+    :param exclude_in_url: Optional filter to exclude URLs containing this string
+    :return: List of last API requests
     """
-
-    last_requests_sql = (
+    query = (
         session.query(APIRequestSQL)
         .distinct(APIRequestSQL.user_uuid)
         .join(UserSQL)
         .options(contains_eager(APIRequestSQL.user))
         .populate_existing()
         .order_by(APIRequestSQL.user_uuid, APIRequestSQL.created_utc.desc())
-        .all()
     )
-
-    return last_requests_sql
-
+    
+    # Apply URL filtering if specified
+    if include_in_url is not None:
+        query = query.filter(APIRequestSQL.url.like(f'%{include_in_url}%'))
+    
+    if exclude_in_url is not None:
+        query = query.filter(~APIRequestSQL.url.like(f'%{exclude_in_url}%'))
+    
+    return query.all()
 
 def get_api_requests_for_one_user(
     session: Session,
     email: str,
     start_datetime: Optional[datetime] = None,
     end_datetime: Optional[datetime] = None,
+    include_in_url: Optional[str] = None,
+    exclude_in_url: Optional[str] = None,
 ) -> List[APIRequestSQL]:
     """
     Get all api requests for one user
-
     :param session: database session
     :param email: user email
     :param start_datetime: only get api requests after start datetime
     :param end_datetime: only get api requests before end datetime
+    :param include_in_url: Optional filter to include only URLs containing this string
+    :param exclude_in_url: Optional filter to exclude URLs containing this string
     """
-
     query = session.query(APIRequestSQL).join(UserSQL).filter(UserSQL.email == email)
-
+    
     if start_datetime is not None:
         query = query.filter(APIRequestSQL.created_utc >= start_datetime)
-
+    
     if end_datetime is not None:
         query = query.filter(APIRequestSQL.created_utc <= end_datetime)
-
-    api_requests = query.order_by(APIRequestSQL.created_utc.desc()).all()
-
-    return api_requests
+    
+    # Apply URL filtering if specified
+    if include_in_url is not None:
+        query = query.filter(APIRequestSQL.url.like(f'%{include_in_url}%'))
+    
+    if exclude_in_url is not None:
+        query = query.filter(~APIRequestSQL.url.like(f'%{exclude_in_url}%'))
+    
+    return query.order_by(APIRequestSQL.created_utc.desc()).all()

--- a/tests/read/test_read_user.py
+++ b/tests/read/test_read_user.py
@@ -40,22 +40,18 @@ def test_get_api_requests_for_one_user(db_session):
     user = get_user(session=db_session, email="test@test.com")
     db_session.add(APIRequestSQL(user_uuid=user.uuid, url="test"))
     db_session.add(APIRequestSQL(user_uuid=user.uuid, url="test2"))
-    
+
     requests_sql = get_api_requests_for_one_user(session=db_session, email=user.email)
-    assert len(requests_sql) == 2 
+    assert len(requests_sql) == 2
 
     include_filtered = get_api_requests_for_one_user(
-        session=db_session,
-        email=user.email,
-        include_in_url="test"
+        session=db_session, email=user.email, include_in_url="test"
     )
     assert len(include_filtered) == 1
     assert include_filtered[0].url == "test"
 
     exclude_filtered = get_api_requests_for_one_user(
-        session=db_session,
-        email=user.email,
-        exclude_in_url="test2"
+        session=db_session, email=user.email, exclude_in_url="test2"
     )
     assert len(exclude_filtered) == 1
     assert exclude_filtered[0].url == "test"

--- a/tests/read/test_read_user.py
+++ b/tests/read/test_read_user.py
@@ -39,10 +39,26 @@ def test_get_all_last_api_request(db_session):
 def test_get_api_requests_for_one_user(db_session):
     user = get_user(session=db_session, email="test@test.com")
     db_session.add(APIRequestSQL(user_uuid=user.uuid, url="test"))
-
+    db_session.add(APIRequestSQL(user_uuid=user.uuid, url="test2"))
+    
     requests_sql = get_api_requests_for_one_user(session=db_session, email=user.email)
-    assert len(requests_sql) == 1
-    assert requests_sql[0].url == "test"
+    assert len(requests_sql) == 2 
+
+    include_filtered = get_api_requests_for_one_user(
+        session=db_session,
+        email=user.email,
+        include_in_url="test"
+    )
+    assert len(include_filtered) == 1
+    assert include_filtered[0].url == "test"
+
+    exclude_filtered = get_api_requests_for_one_user(
+        session=db_session,
+        email=user.email,
+        exclude_in_url="test2"
+    )
+    assert len(exclude_filtered) == 1
+    assert exclude_filtered[0].url == "test"
 
 
 def test_get_api_requests_for_one_user_start_datetime(db_session):


### PR DESCRIPTION
## Description
Adds URL filtering capabilities to API request retrieval functions, enabling more granular control over request filtering.

### Changes
- Added `include_in_url` and `exclude_in_url` optional parameters to API request retrieval functions
- Implemented URL-based filtering using SQLAlchemy's `like()` method

## Fixes
Fixes #298 with ability to filter API requests by URL content.

## How Has This Been Tested?
- Manual testing of new filtering parameters
- Verified compatibility with existing codebase

### Test Configuration
- Python 3.8+
- SQLAlchemy 1.4.x
- Pytest for unit testing

## Checklist
- [x] Follows OCF coding style guidelines
- [x] Performed self-review of code
- [x] Updated inline documentation
- [ ] Added test cases (to be implemented)
- [x] Checked and corrected misspellings
- [x] Maintained existing function behavior