### PR TITLE
[issue309] dont update timestamp if older

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# vim
+*swp

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -91,7 +91,8 @@ def update_latest_input_data_last_updated(
     :param session:
     :param component: This should be gsp, pv, nwp or satellite
     :param update_datetime: the datetime is should be updated.
-        Default is None, so will be set to now
+        Default is None, so will be set to utc now. If without tz, assumed
+        to be in utc.
     :return:
     """
 
@@ -99,8 +100,13 @@ def update_latest_input_data_last_updated(
     # This may be a problem if these function is run at the same twice,
     # but for the moment lets ignore this
 
+    if not hasattr(InputDataLastUpdatedSQL, component):
+        raise AttributeError(f"unsupported {component=}")
+
     if update_datetime is None:
         update_datetime = datetime.now(tz=timezone.utc)
+    if update_datetime.tzinfo is None:
+        update_datetime = update_datetime.astimezone(timezone.utc)
 
     # get latest
     latest_input_data_last_updated = get_latest_input_data_last_updated(session=session)
@@ -112,6 +118,10 @@ def update_latest_input_data_last_updated(
             gsp=now, nwp=now, pv=now, satellite=now
         )
     else:
+        latest_last_updated = getattr(latest_input_data_last_updated, component)
+        # in case this update is actually old, do nothing
+        if latest_last_updated >= update_datetime:
+            return
         # make new object
         new_input_data_last_updated = InputDataLastUpdatedSQL(
             gsp=latest_input_data_last_updated.gsp,

--- a/tests/read/test_read.py
+++ b/tests/read/test_read.py
@@ -450,6 +450,13 @@ def test_update_latest_input_data_last_updated(db_session):
     assert input_data_last_updated.gsp.replace(tzinfo=None) == now
     assert input_data_last_updated.pv.replace(tzinfo=None) == yesterday
 
+    # test that outdated update does not update the value backwards in time
+    update_latest_input_data_last_updated(
+        session=db_session, component="gsp", update_datetime=yesterday
+    )
+    input_data_last_updated = get_latest_input_data_last_updated(session=db_session)
+    assert input_data_last_updated.gsp.replace(tzinfo=None) == now
+
     assert len(db_session.query(InputDataLastUpdatedSQL).all()) == 2
 
 


### PR DESCRIPTION
# Pull Request

## Description

Fixes [issue 309](https://github.com/openclimatefix/nowcasting_datamodel/issues/309)

There is one caveat -- to be able to compare datetimes for deciding whether an update should be done, they either both need to be tz-aware, or both tz-naive. I'm not sure what is the design intent, as the codebase and tests are mixed up. I chose in this PR to always use tz-aware, and default to utc upon update with a tz-naive value. *However*, if there are existing databases out there which contain tz-naive datetimes, this is not enough and we should either do a migration, or add one more check/cast in the update function. The other option is not to cast upon update, but only for the sake of comparison -- thats a bit safer, but a bit weaker in terms of giving a consistent db.

## How Has This Been Tested?

- [x] Yes, existing test case has been extended

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] I believe data processing is not affected

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
