### PR TITLE
Feat/fake data tweaks

### DIFF
--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -14,9 +14,11 @@ from nowcasting_datamodel.models import (
     MLModelSQL,
     PVSystemSQL,
     national_gb_label,
-    ForecastValueLatestSQL,
 )
-from nowcasting_datamodel.models.forecast import ForecastSQL, ForecastValueSQL, ForecastValueSevenDaysSQL
+from nowcasting_datamodel.models.forecast import (
+    ForecastSQL,
+    ForecastValueSQL,
+)
 from nowcasting_datamodel.models.gsp import GSPYieldSQL
 from nowcasting_datamodel.read.read import get_location
 from nowcasting_datamodel.read.read_metric import get_datetime_interval
@@ -130,6 +132,7 @@ def make_fake_forecast(
 
     return forecast
 
+
 def generate_fake_forecasts(
     gsp_ids: List[int],
     session: Session,
@@ -140,7 +143,7 @@ def generate_fake_forecasts(
     model_name: Optional[str] = "fake_model",
     n_fake_forecasts: Optional[int] = N_FAKE_FORECASTS,
 ) -> List[ForecastSQL]:
-    """ Generate fake forecasts """
+    """Generate fake forecasts"""
     forecasts = []
     for gsp_id in gsp_ids:
         forecasts.append(
@@ -157,6 +160,7 @@ def generate_fake_forecasts(
         )
 
     return forecasts
+
 
 def make_fake_forecasts(
     gsp_ids: List[int],

--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -92,7 +92,7 @@ def make_fake_forecast(
     if t0_datetime_utc is None:
         t0_datetime_utc = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
-    random_factor = 0.8 + 0.1 * np.random.random()
+    random_factor = 0.9 + 0.1 * np.random.random()
 
     # create
     if forecast_values is None:
@@ -249,8 +249,8 @@ def make_fake_gsp_yields_for_one_location(
         session=session, gsp_id=gsp_id, installed_capacity_mw=installed_capacity_mw
     )
 
-    random_factor_in_day = 0.8 + 0.1 * np.random.random()
-    random_factor_day_after = 0.8 + 0.1 * np.random.random()
+    random_factor_in_day = 0.7 + 0.1 * np.random.random()
+    random_factor_day_after = 0.7 + 0.1 * np.random.random()
 
     # make 2 days of fake data
     # TODO: this should now be 48hr backwards & ~36hr forwards

--- a/nowcasting_datamodel/read/read.py
+++ b/nowcasting_datamodel/read/read.py
@@ -365,7 +365,8 @@ def get_latest_forecast_for_gsps(
         query = query.options(joinedload(ForecastSQL.location))
         query = query.options(joinedload(ForecastSQL.model))
         query = query.options(joinedload(ForecastSQL.input_data_last_updated))
-        query = query.options(joinedload(ForecastSQL.forecast_values))
+        if not historic:
+            query = query.options(joinedload(ForecastSQL.forecast_values))
 
     order_by_cols.append(desc(ForecastSQL.created_utc))
     query = query.order_by(*order_by_cols)
@@ -381,8 +382,12 @@ def get_latest_forecast_for_gsps(
     # add utc timezone
     for forecast in forecasts:
         forecast.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
-        for forecast_value in forecast.forecast_values:
-            forecast_value.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
+        if forecast.historic:
+            for forecast_value in forecast.forecast_values_latest:
+                forecast_value.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
+        else:
+            for forecast_value in forecast.forecast_values:
+                forecast_value.created_utc = forecast.created_utc.replace(tzinfo=timezone.utc)
 
     return forecasts
 

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -68,13 +68,17 @@ def test_make_fake_forecast(db_session):
     db_session.commit()
     _ = db_session.execute(text("SELECT * FROM forecast_value_2023_01")).all()
 
+
 def test_generate_fake_forecasts(db_session):
-    fake_forecasts = generate_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=True)
+    fake_forecasts = generate_fake_forecasts(
+        session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=True
+    )
 
     assert len(db_session.query(ForecastSQL).all()) == 0
     assert len(db_session.query(ForecastValueSQL).all()) == 0
     assert len(db_session.query(ForecastValueLatestSQL).all()) == 0
     assert len(fake_forecasts) == 4
+
 
 def test_make_fake_forecasts(db_session):
     make_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=True)
@@ -82,6 +86,7 @@ def test_make_fake_forecasts(db_session):
     assert len(db_session.query(ForecastSQL).all()) == 4
     assert len(db_session.query(ForecastValueSQL).all()) == 4 * 112
     assert len(db_session.query(ForecastValueLatestSQL).all()) == 4 * 112
+
 
 def test_make_fake_forecasts_without_latest(db_session):
     make_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=False)

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from nowcasting_datamodel.fake import (
+    generate_fake_forecasts,
     make_fake_forecast,
     make_fake_forecast_value,
     make_fake_forecasts,
@@ -67,13 +68,27 @@ def test_make_fake_forecast(db_session):
     db_session.commit()
     _ = db_session.execute(text("SELECT * FROM forecast_value_2023_01")).all()
 
+def test_generate_fake_forecasts(db_session):
+    fake_forecasts = generate_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=True)
+
+    assert len(db_session.query(ForecastSQL).all()) == 0
+    assert len(db_session.query(ForecastValueSQL).all()) == 0
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 0
+    assert len(fake_forecasts) == 4
 
 def test_make_fake_forecasts(db_session):
     make_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=True)
 
-    assert len(db_session.query(ForecastSQL).all()) > 0
-    assert len(db_session.query(ForecastValueLatestSQL).all()) > 0
-    assert len(db_session.query(ForecastValueSQL).all()) > 0
+    assert len(db_session.query(ForecastSQL).all()) == 4
+    assert len(db_session.query(ForecastValueSQL).all()) == 4 * 112
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 4 * 112
+
+def test_make_fake_forecasts_without_latest(db_session):
+    make_fake_forecasts(session=db_session, gsp_ids=[0, 1, 2, 3], add_latest=False)
+
+    assert len(db_session.query(ForecastSQL).all()) == 4
+    assert len(db_session.query(ForecastValueSQL).all()) == 4 * 112
+    assert len(db_session.query(ForecastValueLatestSQL).all()) == 0
 
 
 def test_make_national_fake_forecast(db_session):


### PR DESCRIPTION
# Pull Request

## Description

- Correct minor oddity between `forecast_values` and `forecast_values_latest` in query;
- Break the `make_fake_forecasts` function out with intermediary function to be able to separately generate forecasts and return them, without adding to the `db_session` for more versatile use;
- Tweak fake forecast generation values (more improvements to be done here for sure, will make a **good first issue** or two!

## How Has This Been Tested?

Added new test for generated fake forecasts

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
