### PR TITLE
add forecast_creation_time option to make fake forecast

### DIFF
--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -74,6 +74,7 @@ def make_fake_forecast(
     historic: Optional[bool] = False,
     model_name: Optional[str] = "fake_model",
     n_fake_forecasts: Optional[int] = N_FAKE_FORECASTS,
+    forecast_creation_time: Optional[datetime] = None,
 ) -> ForecastSQL:
     """Make one fake forecast"""
 
@@ -83,6 +84,9 @@ def make_fake_forecast(
     else:
         # gsp capacity (roughly)
         installed_capacity_mw = 40
+
+    if forecast_creation_time is None:
+        forecast_creation_time = t0_datetime_utc
 
     location = get_location(
         gsp_id=gsp_id, session=session, installed_capacity_mw=installed_capacity_mw
@@ -122,7 +126,7 @@ def make_fake_forecast(
 
     forecast = ForecastSQL(
         model=model,
-        forecast_creation_time=t0_datetime_utc,
+        forecast_creation_time=forecast_creation_time,
         location=location,
         input_data_last_updated=input_data_last_updated,
         forecast_values=forecast_values,

--- a/nowcasting_datamodel/fake.py
+++ b/nowcasting_datamodel/fake.py
@@ -85,9 +85,6 @@ def make_fake_forecast(
         # gsp capacity (roughly)
         installed_capacity_mw = 40
 
-    if forecast_creation_time is None:
-        forecast_creation_time = t0_datetime_utc
-
     location = get_location(
         gsp_id=gsp_id, session=session, installed_capacity_mw=installed_capacity_mw
     )
@@ -97,6 +94,9 @@ def make_fake_forecast(
 
     if t0_datetime_utc is None:
         t0_datetime_utc = datetime(2024, 1, 1, tzinfo=timezone.utc)
+
+    if forecast_creation_time is None:
+        forecast_creation_time = t0_datetime_utc
 
     random_factor = 0.9 + 0.1 * np.random.random()
 

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -68,19 +68,21 @@ def test_make_fake_forecast(db_session):
     db_session.commit()
     _ = db_session.execute(text("SELECT * FROM forecast_value_2023_01")).all()
 
+
 def test_make_fake_forecast_with_creation_time(db_session):
     t0 = datetime(2023, 1, 1, tzinfo=timezone.utc)
     forecast_creation_time = datetime(2023, 1, 1, 1, tzinfo=timezone.utc)
-    forecast_sql: ForecastSQL = make_fake_forecast(gsp_id=1,
-                                                   session=db_session,
-                                                   t0_datetime_utc=t0)
+    forecast_sql: ForecastSQL = make_fake_forecast(gsp_id=1, session=db_session, t0_datetime_utc=t0)
     assert forecast_sql.forecast_creation_time == t0
 
-    forecast_sql: ForecastSQL = make_fake_forecast(gsp_id=1,
-                                                   session=db_session,
-                                                   t0_datetime_utc=t0,
-                                                   forecast_creation_time=forecast_creation_time)
+    forecast_sql: ForecastSQL = make_fake_forecast(
+        gsp_id=1,
+        session=db_session,
+        t0_datetime_utc=t0,
+        forecast_creation_time=forecast_creation_time,
+    )
     assert forecast_sql.forecast_creation_time == forecast_creation_time
+
 
 def test_generate_fake_forecasts(db_session):
     fake_forecasts = generate_fake_forecasts(

--- a/tests/test_fake.py
+++ b/tests/test_fake.py
@@ -68,6 +68,19 @@ def test_make_fake_forecast(db_session):
     db_session.commit()
     _ = db_session.execute(text("SELECT * FROM forecast_value_2023_01")).all()
 
+def test_make_fake_forecast_with_creation_time(db_session):
+    t0 = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    forecast_creation_time = datetime(2023, 1, 1, 1, tzinfo=timezone.utc)
+    forecast_sql: ForecastSQL = make_fake_forecast(gsp_id=1,
+                                                   session=db_session,
+                                                   t0_datetime_utc=t0)
+    assert forecast_sql.forecast_creation_time == t0
+
+    forecast_sql: ForecastSQL = make_fake_forecast(gsp_id=1,
+                                                   session=db_session,
+                                                   t0_datetime_utc=t0,
+                                                   forecast_creation_time=forecast_creation_time)
+    assert forecast_sql.forecast_creation_time == forecast_creation_time
 
 def test_generate_fake_forecasts(db_session):
     fake_forecasts = generate_fake_forecasts(


### PR DESCRIPTION
# Pull Request

## Description

add an option to add forecast_creation_time when making a fake forecast

#316 

## How Has This Been Tested?

- [ ] CI
- [x] added a new test

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
