### PR TITLE
Fix for forecast latest init time

### DIFF
--- a/nowcasting_datamodel/models/forecast.py
+++ b/nowcasting_datamodel/models/forecast.py
@@ -478,7 +478,9 @@ class Forecast(EnhancedBaseModel):
     )
 
     initialization_datetime_utc: datetime = Field(
-        ..., description="The time when the forecast should be initialized"
+        ...,
+        description="The time when the forecast should be initialized",
+        exclude=True,
     )
 
     @field_validator("forecast_creation_time", mode="before")

--- a/nowcasting_datamodel/save/update.py
+++ b/nowcasting_datamodel/save/update.py
@@ -50,6 +50,7 @@ def get_historic_forecast(
             location=forecast.location,
             input_data_last_updated=forecast.input_data_last_updated,
             model=forecast.model,
+            initialization_datetime_utc=datetime.now(timezone.utc),
         )
         session.add(forecast_historic)
         session.commit()

--- a/tests/save/test_update.py
+++ b/tests/save/test_update.py
@@ -11,6 +11,7 @@ from nowcasting_datamodel.fake import (
 from nowcasting_datamodel.read.read_models import get_model
 from nowcasting_datamodel.models import ForecastValueSevenDaysSQL
 from nowcasting_datamodel.models.forecast import (
+    Forecast,
     ForecastSQL,
     ForecastValueLatestSQL,
     ForecastValueSQL,
@@ -91,6 +92,8 @@ def test_update_one_gsp(db_session):
     forecast = db_session.query(ForecastSQL).filter(ForecastSQL.historic == True).first()
     assert forecast.input_data_last_updated == forecast_sql.input_data_last_updated
 
+    # make sure we can convert to pydantic object
+    _ = Forecast.from_orm(forecast)
 
 @freeze_time("2024-01-01 00:00:00")
 def test_update_all_forecast_latest(db_session):


### PR DESCRIPTION
# Pull Request

## Description

Fix for init datetime

This will help https://github.com/openclimatefix/uk-pv-national-gsp-api/pull/426

## How Has This Been Tested?

CI tests
- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
